### PR TITLE
Finalize GitHub-oriented CI

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -4,11 +4,14 @@ on:
     branches: ["develop"]
     tags: ["v*"]
   pull_request:
+    types: [ labeled ]
     branches:
       - "develop"
 
 jobs:
   docker:
+    name: Build Docker image
+    if: ${{ github.event.label.name == 'build-docker-image' }}
     runs-on: ubuntu-latest
     steps:
       - name: Extract Docker metadata

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -1,10 +1,23 @@
-name: Deploy packages
+name: Deploy release
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - v*
 
 jobs:
+  create_release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Creating release
+        run: |
+          export TAG="${{ github.ref_name }}"
+          gh release create ${{ github.ref_name }} -R ${{ github.repository }} --verify-tag --title "Version ${TAG:1}" --generate-notes --draft
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   macos:
+    name: Create macOS package (Intel)
+    needs: create_release
     runs-on: macos-12
     timeout-minutes: 240
     env:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,5 +1,11 @@
 name: Unit tests
-on: [push, pull_request]
+on:
+  push:
+    branches: ["develop"]
+  pull_request:
+    branches:
+      - "develop"
+
 concurrency:
   group: "${{ github.ref }}"
   cancel-in-progress: true

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   debian_static:
+    name: Debian 11 (static libraries)
     runs-on: ubuntu-latest
     container: ghcr.io/educelab/ci-docker:11_v2.static
     if: ${{ github.event_name }} == "merge_request_event" || !(${{ github.ref }} && $CI_OPEN_MERGE_REQUESTS) || ${{ github.ref }}
@@ -33,6 +34,7 @@ jobs:
       run: ctest -V --test-dir build/
 
   debian_dynamic:
+    name: Debian 11 (shared libraries)
     runs-on: ubuntu-latest
     container: ghcr.io/educelab/ci-docker:11_v2.dynamic
     if: ${{ github.event_name }} == "merge_request_event" || !(${{ github.ref }} && $CI_OPEN_MERGE_REQUESTS) || ${{ github.ref }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -233,7 +233,7 @@ release:create:gitlab:
     tags:
         - docker
 
-release:create:github:
+release:upload:github:
     stage: release
     image: debian:bullseye
     needs: ["collect:binaries:macos:release"]
@@ -248,13 +248,10 @@ release:create:github:
         - apt install gh -y
     script:
         - >
-            gh release create 
+            gh release upload
             "$CI_COMMIT_TAG" 
             "${PACKAGE_NAME}"
             -R educelab/volume-cartographer
-            --verify-tag 
-            --title "Version ${CI_COMMIT_TAG:1}"
-            --generate-notes
-            --draft
+            --clobber
     tags:
         - docker


### PR DESCRIPTION
Migrates release creation to GitHub actions. macOS Arm package building still happens behind the scenes on GitLab.