### PR TITLE
Remove brew libtiff from macOS Intel packages

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -1,0 +1,74 @@
+name: Build packages
+
+on:
+  workflow_call:
+    outputs:
+      package_mac_intel:
+        description: "The file name of the macOS Intel package"
+        value: ${{ jobs.build_macos_intel.outputs.package_name }}
+
+jobs:
+  build_macos_intel:
+    name: Create macOS package (Intel)
+    runs-on: macos-12
+    outputs:
+      package_name: ${{ steps.name_pkg.outputs.package_name }}
+    timeout-minutes: 240
+    env:
+      QT_VERSION: "6.4.2"
+      EXTRA_CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=Release -DVC_PREBUILT_LIBS=ON -DVC_BUILD_ACVD=ON"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.3.0
+        with:
+          fetch-depth: 20
+
+      - name: Install Homebrew dependencies
+        run: |
+          brew update
+          brew unlink libtiff
+          brew install ninja python@3.10
+
+      - name: Install Qt6
+        run: |
+          python3.10 -m pip install --upgrade pip setuptools wheel
+          python3.10 -m pip install aqtinstall
+          aqt install-qt -O ${{ github.workspace }}/Qt/ mac desktop ${QT_VERSION}
+
+      - name: Install vc-deps
+        run: |
+          git submodule update --init
+          cmake -S vc-deps/ -B vc-deps/build/ -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_MESSAGE=NEVER -DVCDEPS_BUILD_ACVD=OFF
+          cmake --build vc-deps/build/
+
+      - name: Build volume-cartographer
+        run: |
+          export CMAKE_INSTALL_PREFIX="packaged_install/"
+          cmake -S . -B build/ -GNinja ${EXTRA_CMAKE_FLAGS} -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Qt/${QT_VERSION}/macos/lib/cmake/
+          cmake --build build/
+          echo "install_dir=${CMAKE_INSTALL_PREFIX}" >> ${GITHUB_ENV}
+
+      - name: Generate package name
+        id: name_pkg
+        run: |
+          ARCH=$(uname -m)
+          if [[ ${{ github.ref }} =~ ^refs/tags/v* ]]; then
+            PKG_NAME="VC-${GITHUB_REF_NAME:1}-Darwin-${ARCH}.zip"
+          else
+            PKG_NAME="VC-${GITHUB_REF_NAME}-Darwin-${ARCH}.zip"
+          fi  
+          echo "package_name=${PKG_NAME}" >> ${GITHUB_ENV}
+          echo "package_name=${PKG_NAME}" >> ${GITHUB_OUTPUT} 
+
+      - name: Create package
+        run: |
+          cmake --install build/ --prefix "${{ env.install_dir }}"
+          python3.10 utils/scripts/macos_codesign_release.py -i "${{ env.install_dir }}"
+          ditto -c -k "${{ env.install_dir }}" ${{ env.package_name }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3.1.1
+        if: success()
+        with:
+          name: package-macos-intel
+          path: ${{ env.package_name }}

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -15,62 +15,26 @@ jobs:
           gh release create ${{ github.ref_name }} -R ${{ github.repository }} --verify-tag --title "Version ${TAG:1}" --generate-notes --draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   macos:
     name: Create macOS package (Intel)
     needs: create_release
-    runs-on: macos-12
-    timeout-minutes: 240
-    env:
-      QT_VERSION: "6.4.2"
-      EXTRA_CMAKE_FLAGS: "-DCMAKE_BUILD_TYPE=Release -DVC_PREBUILT_LIBS=ON -DVC_BUILD_ACVD=ON"
+    uses: ./.github/workflows/build_packages.yml
+
+  upload_packages:
+    name: Upload to release
+    runs-on: ubuntu-latest
+    needs: macos
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3.3.0
+      - name: Download macOS (Intel) package
+        uses: actions/download-artifact@master
         with:
-          fetch-depth: 20
+          name: package-macos-intel
+          path: ${{ needs.macos.outputs.package_mac_intel }}
 
-      - name: Install Homebrew dependencies
-        run: |
-          brew update
-          brew install ninja python@3.10
-
-      - name: Install Qt6
-        run: |
-          python3.10 -m pip install --upgrade pip setuptools wheel
-          python3.10 -m pip install aqtinstall
-          aqt install-qt -O ${{ github.workspace }}/Qt/ mac desktop ${QT_VERSION}
-
-      - name: Install vc-deps
-        run: |
-          git submodule update --init
-          cmake -S vc-deps/ -B vc-deps/build/ -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_MESSAGE=NEVER -DVCDEPS_BUILD_ACVD=OFF
-          cmake --build vc-deps/build/
-
-      - name: Build volume-cartographer
-        run: |
-          export CMAKE_INSTALL_PREFIX="packaged_install/"
-          cmake -S . -B build/ -GNinja ${EXTRA_CMAKE_FLAGS} -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Qt/${QT_VERSION}/macos/lib/cmake/
-          cmake --build build/
-          echo "install_dir=${CMAKE_INSTALL_PREFIX}" >> ${GITHUB_ENV}
-
-      - name: Create package
-        run: |
-          cmake --install build/ --prefix "${{ env.install_dir }}"
-          python3.10 utils/scripts/macos_codesign_release.py -i "${{ env.install_dir }}"
-          ARCH=$(uname -m)
-          PKG_NAME="VC-${GITHUB_REF_NAME:1}-Darwin-${ARCH}.zip"
-          ditto -c -k "${{ env.install_dir }}" ${PKG_NAME}
-          echo "package_name=${PKG_NAME}" >> ${GITHUB_ENV}
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3.1.1
-        if: success()
-        with:
-          path: ${{ env.package_name }}
-
-      - name: Upload to release
+      - name: Upload packages
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          gh release upload ${{ github.ref_name }} "${{ env.package_name }}" -R ${{ github.repository }} --clobber
+          gh release upload ${{ github.ref_name }} "${{ needs.macos.outputs.package_mac_intel }}" -R ${{ github.repository }} --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on_labels.yml
+++ b/.github/workflows/on_labels.yml
@@ -1,0 +1,11 @@
+name: Label jobs
+on:
+  pull_request:
+    types: [labeled]
+    branches: ["develop"]
+
+jobs:
+  build_pre_macos_intel:
+    name: Build pre-release macOS (Intel) package
+    if: ${{ github.event.label.name == 'build-packages' }}
+    uses: ./.github/workflows/build_packages.yml


### PR DESCRIPTION
Unlinks Homebrew's libtiff when building the macOS Intel packages (fixes #5).

Also refactors package building into a reusable workflow so we can build packages with labels.