### PR TITLE
(VC) Fix crashes when running segmentation tool

### DIFF
--- a/apps/VC/CVolumeViewerWithCurve.cpp
+++ b/apps/VC/CVolumeViewerWithCurve.cpp
@@ -322,12 +322,9 @@ void CVolumeViewerWithCurve::DrawIntersectionCurve(void)
         int b{0};
         colorSelector->color().getRgb(&r, &g, &b);
         for (size_t i = 0; i < fIntersectionCurveRef->GetPointsNum(); ++i) {
-            cv::circle(
-                fImgMat,
-                cv::Point2d(
-                    fIntersectionCurveRef->GetPoint(i)[0],
-                    fIntersectionCurveRef->GetPoint(i)[1]),
-                1, cv::Scalar(b, g, r));
+            auto p0 = fIntersectionCurveRef->GetPoint(i)[0] - 0.5;
+            auto p1 = fIntersectionCurveRef->GetPoint(i)[1] - 0.5;
+            cv::circle(fImgMat, cv::Point2d(p0, p1), 1, cv::Scalar(b, g, r));
         }
     }
 }

--- a/apps/VC/CWindow.cpp
+++ b/apps/VC/CWindow.cpp
@@ -320,17 +320,14 @@ bool CWindow::InitializeVolumePkg(const std::string& nVpkgPath)
 
     try {
         fVpkg = vc::VolumePkg::New(nVpkgPath);
-    } catch (...) {
-        std::cerr << "VC::Error: Volume package failed to initialize."
-                  << std::endl;
+    } catch (const std::exception& e) {
+        vc::Logger()->error("Failed to initialize volpkg: {}", e.what());
     }
 
     fVpkgChanged = false;
 
     if (fVpkg == nullptr) {
-        std::cerr
-            << "VC::Error: Cannot open volume package at specified location: "
-            << nVpkgPath << std::endl;
+        vc::Logger()->error("Cannot open .volpkg: {}", nVpkgPath);
         QMessageBox::warning(
             this, "Error",
             "Volume package failed to load. Package might be corrupt.");
@@ -635,8 +632,7 @@ void CWindow::SetUpCurves(void)
 {
     if (fVpkg == nullptr || fMasterCloud.empty()) {
         statusBar->showMessage(tr("Selected point cloud is empty"));
-        std::cerr << "VC::Warning: Point cloud for this segmentation is empty."
-                  << std::endl;
+        vc::Logger()->warn("Segmentation point cloud is empty");
         return;
     }
     fIntersections.clear();
@@ -748,19 +744,19 @@ void CWindow::OpenVolume()
         QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
     // Dialog box cancelled
     if (aVpkgPath.length() == 0) {
-        std::cerr << "VC::Message: Open volume package cancelled." << std::endl;
+        vc::Logger()->info("Open .volpkg canceled");
         return;
     }
 
     // Checks the Folder Path for .volpkg extension
-    std::string extension = aVpkgPath.toStdString().substr(
+    auto const extension = aVpkgPath.toStdString().substr(
         aVpkgPath.toStdString().length() - 7, aVpkgPath.toStdString().length());
-    if (extension.compare(".volpkg") != 0) {
+    if (extension == ".volpkg") {
         QMessageBox::warning(
             this, tr("ERROR"),
             "The selected file is not of the correct type: \".volpkg\"");
-        std::cerr << "VC::Error: Selected file: " << aVpkgPath.toStdString()
-                  << " is of the wrong type." << std::endl;
+        vc::Logger()->error(
+            "Selected file is not .volpkg: {}", aVpkgPath.toStdString());
         fVpkg = nullptr;  // Is need for User Experience, clears screen.
         return;
     }
@@ -775,11 +771,11 @@ void CWindow::OpenVolume()
 
     // Check version number
     if (fVpkg->version() != VOLPKG_SUPPORTED_VERSION) {
-        std::string msg = "VC::Error: Volume package is version " +
-                          std::to_string(fVpkg->version()) +
-                          " but this program requires a version " +
-                          std::to_string(VOLPKG_SUPPORTED_VERSION) + ".";
-        std::cerr << msg << std::endl;
+        const auto msg = "Volume package is version " +
+                         std::to_string(fVpkg->version()) +
+                         " but this program requires version " +
+                         std::to_string(VOLPKG_SUPPORTED_VERSION) + ".";
+        vc::Logger()->error(msg);
         QMessageBox::warning(this, tr("ERROR"), QString(msg.c_str()));
         fVpkg = nullptr;
         return;
@@ -846,11 +842,10 @@ void CWindow::About(void)
 }
 
 // Save point cloud to path directory
-void CWindow::SavePointCloud(void)
+void CWindow::SavePointCloud()
 {
     if (fMasterCloud.empty()) {
-        std::cerr << "VC::message: Empty point cloud. Nothing to save."
-                  << std::endl;
+        vc::Logger()->debug("Empty point cloud. Nothing to save.");
         return;
     }
 
@@ -864,8 +859,8 @@ void CWindow::SavePointCloud(void)
         return;
     }
 
-    statusBar->showMessage(tr("Volume saved."), 5000);
-    std::cerr << "VC::message: Volume saved." << std::endl;
+    statusBar->showMessage(tr("Volume Package saved."), 5000);
+    vc::Logger()->info("Volume Package saved");
     fVpkgChanged = false;
 }
 
@@ -873,16 +868,16 @@ void CWindow::SavePointCloud(void)
 void CWindow::OnNewPathClicked(void)
 {
     // Save if we need to
-    if (SaveDialog() == SaveResponse::Cancelled)
+    if (SaveDialog() == SaveResponse::Cancelled) {
         return;
+    }
 
     // Make a new segmentation in the volpkg
     auto seg = fVpkg->newSegmentation();
-    std::string newSegmentationId = seg->id();
+    const auto newSegmentationId = seg->id();
 
     // add new path to path list
-    QListWidgetItem* aNewPath =
-        new QListWidgetItem(QString(newSegmentationId.c_str()));
+    auto* aNewPath = new QListWidgetItem(QString(newSegmentationId.c_str()));
     fPathListWidget->addItem(aNewPath);
 
     // Make sure we stay on the current slice

--- a/apps/VC/CWindow.hpp
+++ b/apps/VC/CWindow.hpp
@@ -112,7 +112,7 @@ private slots:
     void Open(void);
     void Close(void);
     void About(void);
-    void SavePointCloud(void);
+    void SavePointCloud();
 
     void OnNewPathClicked(void);
     void OnPathItemClicked(QListWidgetItem* nItem);

--- a/apps/VC/CWindow.hpp
+++ b/apps/VC/CWindow.hpp
@@ -63,6 +63,7 @@ signals:
 
 public slots:
     void onSegmentationFinished(Segmenter::PointSet ps);
+    void onSegmentationFailed(std::string s);
 
 public:
     CWindow();
@@ -231,6 +232,7 @@ public:
 signals:
     void segmentationStarted(size_t);
     void segmentationFinished(CWindow::Segmenter::PointSet ps);
+    void segmentationFailed(std::string);
     void progressUpdated(size_t);
 
 public slots:
@@ -240,8 +242,12 @@ public slots:
         segmenter.progressUpdated.connect(
             [=](size_t p) { progressUpdated(p); });
         segmentationStarted(segmenter.progressIterations());
-        auto result = segmenter.compute();
-        segmentationFinished(result);
+        try {
+            auto result = segmenter.compute();
+            segmentationFinished(result);
+        } catch (const std::exception& e) {
+            segmentationFailed(e.what());
+        }
     }
 
 public:

--- a/core/src/Volume.cpp
+++ b/core/src/Volume.cpp
@@ -185,10 +185,6 @@ Reslice Volume::reslice(
     int width,
     int height) const
 {
-    if (!isInBounds(center)) {
-        throw std::range_error("center not in bounds");
-    }
-
     auto xnorm = cv::normalize(xvec);
     auto ynorm = cv::normalize(yvec);
     auto origin = center - ((width / 2) * xnorm + (height / 2) * ynorm);


### PR DESCRIPTION
This addresses a number of issues that lead to #6.
- The offending segmentation had duplicate, adjacent points. This lead to the creation of a malformed spline between these points that went out of the volume's FOV. The VC GUI now filters out adjacent, duplicate points when creating new segmentations.
- The uncaught exception being thrown was in `Volume::reslice` because the center for a reslice was outside of the volume bounds. This shouldn't really matter for reslicing. Our intensity interpolation handles out-of-bounds volume access (returns 0), so reslicing out there should just be empty. Removed the `throw` for this exception.
- The VC segmentation worker thread had no exception handling. We now catch and gracefully handle `std::exception` rather than just crashing.
- Cleaned up error reporting to use `vc::Logger` so at least console output is consistent.

Fixes #6 