### PR TITLE
(VC) Add ability to swap segmentation algorithms

### DIFF
--- a/apps/VC/CWindow.cpp
+++ b/apps/VC/CWindow.cpp
@@ -11,8 +11,10 @@
 #include "vc/core/types/Exceptions.hpp"
 #include "vc/core/util/Logging.hpp"
 #include "vc/meshing/OrderedPointSetMesher.hpp"
+#include "vc/segmentation/LocalResliceParticleSim.hpp"
 
 namespace vc = volcart;
+namespace vcs = volcart::segmentation;
 using namespace ChaoVis;
 using qga = QGuiApplication;
 
@@ -159,10 +161,17 @@ void CWindow::CreateWidgets(void)
         SLOT(OnPathItemClicked(QListWidgetItem*)));
 
     // segmentation methods
-    QComboBox* aSegMethodsComboBox =
-        this->findChild<QComboBox*>("cmbSegMethods");
+    auto* aSegMethodsComboBox = this->findChild<QComboBox*>("cmbSegMethods");
     aSegMethodsComboBox->addItem(tr("Local Reslice Particle Simulation"));
+    connect(
+        aSegMethodsComboBox, SIGNAL(currentIndexChanged(int)), this,
+        SLOT(OnChangeSegAlgo(int)));
 
+    // ADD NEW SEGMENTATION ALGORITHM NAMES HERE
+    // aSegMethodsComboBox->addItem(tr("My custom algorithm"));
+
+    // LRPS segmentation parameters
+    // all of these are contained in the this->ui.lrpsParams
     fEdtAlpha = this->findChild<QLineEdit*>("edtAlphaVal");
     fEdtBeta = this->findChild<QLineEdit*>("edtBetaVal");
     fEdtDelta = this->findChild<QLineEdit*>("edtDeltaVal");
@@ -201,6 +210,9 @@ void CWindow::CreateWidgets(void)
     connect(
         fEdtEndIndex, SIGNAL(editingFinished()), this,
         SLOT(OnEdtEndingSliceValChange()));
+
+    // INSERT OTHER SEGMENTATION PARAMETER WIDGETS HERE
+    // this->ui.segParamsStack->addWidget(new QLabel("Parameter widgets here"));
 
     // start segmentation button
     QPushButton* aBtnStartSeg = this->findChild<QPushButton*>("btnStartSeg");
@@ -513,29 +525,39 @@ void CWindow::DoSegmentation(void)
 {
     statusBar->clearMessage();
 
-    // REVISIT - do we need to get the latest value from the widgets since we
-    // constantly get the values?
-    if (!SetUpSegParams()) {
+    // Make sure our seg params structure has the current values
+    if (not SetUpSegParams()) {
         QMessageBox::information(
             this, tr("Info"), tr("Invalid parameter for segmentation"));
         return;
     }
 
-    // 2) do segmentation from the starting slice
-    vc::segmentation::LocalResliceSegmentation segmenter;
-    segmenter.setChain(fStartingPath);
-    segmenter.setVolume(currentVolume);
-    segmenter.setMaterialThickness(fVpkg->materialThickness());
-    segmenter.setTargetZIndex(fSegParams.targetIndex);
-    segmenter.setOptimizationIterations(fSegParams.fNumIters);
-    segmenter.setResliceSize(fSegParams.fWindowWidth);
-    segmenter.setAlpha(fSegParams.fAlpha);
-    segmenter.setK1(fSegParams.fK1);
-    segmenter.setK2(fSegParams.fK2);
-    segmenter.setBeta(fSegParams.fBeta);
-    segmenter.setDelta(fSegParams.fDelta);
-    segmenter.setDistanceWeightFactor(fSegParams.fPeakDistanceWeight);
-    segmenter.setConsiderPrevious(fSegParams.fIncludeMiddle);
+    // Setup LRPS
+    auto segIdx = this->ui.cmbSegMethods->currentIndex();
+    Segmenter::Pointer segmenter;
+    if (segIdx == 0) {
+        auto lrps = vcs::LocalResliceSegmentation::New();
+        lrps->setMaterialThickness(fVpkg->materialThickness());
+        lrps->setTargetZIndex(fSegParams.targetIndex);
+        lrps->setOptimizationIterations(fSegParams.fNumIters);
+        lrps->setResliceSize(fSegParams.fWindowWidth);
+        lrps->setAlpha(fSegParams.fAlpha);
+        lrps->setK1(fSegParams.fK1);
+        lrps->setK2(fSegParams.fK2);
+        lrps->setBeta(fSegParams.fBeta);
+        lrps->setDelta(fSegParams.fDelta);
+        lrps->setDistanceWeightFactor(fSegParams.fPeakDistanceWeight);
+        lrps->setConsiderPrevious(fSegParams.fIncludeMiddle);
+        segmenter = lrps;
+    }
+    // ADD OTHER SEGMENTER SETUP HERE. MATCH THE IDX TO THE IDX IN THE
+    // DROPDOWN LIST
+
+    // set common parameters
+    segmenter->setChain(fStartingPath);
+    segmenter->setVolume(currentVolume);
+
+    // setup
     submitSegmentation(segmenter);
     setWidgetsEnabled(false);
     worker_progress_.show();
@@ -959,6 +981,11 @@ void CWindow::ToggleSegmentationTool(void)
         CleanupSegmentation();
     }
     UpdateView();
+}
+
+void CWindow::OnChangeSegAlgo(int index)
+{
+    this->ui.segParamsStack->setCurrentIndex(index);
 }
 
 // Handle gravity value change

--- a/apps/VC/VCMain.ui
+++ b/apps/VC/VCMain.ui
@@ -123,6 +123,9 @@
            <property name="wordWrap">
             <bool>true</bool>
            </property>
+           <property name="buddy">
+            <cstring>segParamsStack</cstring>
+           </property>
           </widget>
          </item>
          <item>
@@ -166,8 +169,7 @@
           </widget>
          </item>
          <item>
-            <widget class="QComboBox" name="volSelect">
-            </widget>
+          <widget class="QComboBox" name="volSelect"/>
          </item>
          <item>
           <widget class="QPushButton" name="assignVol">
@@ -186,7 +188,7 @@
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_4">
          <item>
-          <widget class="QLabel" name="label_5">
+          <widget class="QLabel" name="segMethodLabel">
            <property name="text">
             <string>Method</string>
            </property>
@@ -196,96 +198,100 @@
           <widget class="QComboBox" name="cmbSegMethods"/>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_5">
-           <item>
-            <layout class="QVBoxLayout" name="verticalLayout_6">
+          <widget class="QStackedWidget" name="segParamsStack">
+           <widget class="QWidget" name="lrpsParams" native="true">
+            <layout class="QHBoxLayout" name="lrpsParamsLayout">
              <item>
-              <widget class="QLabel" name="label_6">
-               <property name="text">
-                <string>Distance Weight</string>
-               </property>
-              </widget>
+              <layout class="QVBoxLayout" name="verticalLayout_6">
+               <item>
+                <widget class="QLabel" name="label_6">
+                 <property name="text">
+                  <string>Distance Weight</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="edtDistanceWeightVal"/>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_3">
+                 <property name="text">
+                  <string>Alpha</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="edtAlphaVal"/>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_4">
+                 <property name="text">
+                  <string>Delta</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="edtDeltaVal"/>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_11">
+                 <property name="text">
+                  <string>K2</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="edtK2Val"/>
+               </item>
+              </layout>
              </item>
              <item>
-              <widget class="QLineEdit" name="edtDistanceWeightVal"/>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_3">
-               <property name="text">
-                <string>Alpha</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="edtAlphaVal"/>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_4">
-               <property name="text">
-                <string>Delta</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="edtDeltaVal"/>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_11">
-               <property name="text">
-                <string>K2</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="edtK2Val"/>
+              <layout class="QVBoxLayout" name="verticalLayout_5">
+               <item>
+                <widget class="QLabel" name="label_7">
+                 <property name="text">
+                  <string>Maxima Window Width</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="edtWindowWidthVal"/>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_2">
+                 <property name="text">
+                  <string>Beta</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="edtBetaVal"/>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_10">
+                 <property name="text">
+                  <string>K1</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="edtK1Val"/>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="includeMiddleOpt">
+                 <property name="text">
+                  <string>Consider Previous</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
             </layout>
-           </item>
-           <item>
-            <layout class="QVBoxLayout" name="verticalLayout_5">
-             <item>
-              <widget class="QLabel" name="label_7">
-               <property name="text">
-                <string>Maxima Window Width</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSpinBox" name="edtWindowWidthVal"/>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_2">
-               <property name="text">
-                <string>Beta</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="edtBetaVal"/>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_10">
-               <property name="text">
-                <string>K1</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="edtK1Val"/>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="includeMiddleOpt">
-               <property name="text">
-                <string>Consider Previous</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-          </layout>
+           </widget>
+          </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <layout class="QHBoxLayout" name="startEndLayout">
            <item>
             <layout class="QVBoxLayout" name="verticalLayout_9">
              <item>

--- a/segmentation/include/vc/segmentation/ChainSegmentationAlgorithm.hpp
+++ b/segmentation/include/vc/segmentation/ChainSegmentationAlgorithm.hpp
@@ -71,7 +71,7 @@ public:
 
     /**@{*/
     /** @brief Compute the segmentation */
-    virtual PointSet compute() = 0;
+    virtual auto compute() -> PointSet = 0;
 
     /** @brief Get the status of the previous computation */
     auto getStatus() const -> Status { return status_; }

--- a/segmentation/include/vc/segmentation/ChainSegmentationAlgorithm.hpp
+++ b/segmentation/include/vc/segmentation/ChainSegmentationAlgorithm.hpp
@@ -10,16 +10,19 @@
 namespace volcart::segmentation
 {
 /**
- * @class ChainSegmentationAlgorithmBaseClass
+ * @class ChainSegmentationAlgorithm
  * @author Seth Parker
  * @brief Base class for segmentation algorithms that propagate a collected
  * chain of points
  */
-class ChainSegmentationAlgorithmBaseClass : public IterationsProgress
+class ChainSegmentationAlgorithm : public IterationsProgress
 {
 public:
+    /** Shared pointer type */
+    using Pointer = std::shared_ptr<ChainSegmentationAlgorithm>;
+
     /** Default destructor for virtual base class */
-    virtual ~ChainSegmentationAlgorithmBaseClass() = default;
+    virtual ~ChainSegmentationAlgorithm() = default;
 
     /** Chain type */
     using Chain = std::vector<cv::Vec3d>;
@@ -71,23 +74,26 @@ public:
     virtual PointSet compute() = 0;
 
     /** @brief Get the status of the previous computation */
-    Status getStatus() const { return status_; }
+    auto getStatus() const -> Status { return status_; }
     /**@}*/
 
     /**@{*/
     /** @brief Get the segmented pointset */
-    const PointSet& getPointSet() const { return result_; }
+    [[nodiscard]] auto getPointSet() const -> const PointSet&
+    {
+        return result_;
+    }
 
     /** @copydoc getPointSet() const */
-    PointSet& getPointSet() { return result_; }
+    auto getPointSet() -> PointSet& { return result_; }
     /**@}*/
 
     /** @brief Returns the maximum progress value */
-    size_t progressIterations() const override { return numSteps_; }
+    auto progressIterations() const -> size_t override { return numSteps_; }
 
 protected:
     /** Default constructor */
-    ChainSegmentationAlgorithmBaseClass() = default;
+    ChainSegmentationAlgorithm() = default;
     /** Volume */
     Volume::Pointer vol_;
     /** Seed chain */

--- a/segmentation/include/vc/segmentation/LocalResliceParticleSim.hpp
+++ b/segmentation/include/vc/segmentation/LocalResliceParticleSim.hpp
@@ -6,7 +6,7 @@
 
 #include "vc/core/types/OrderedPointSet.hpp"
 #include "vc/core/types/VolumePkg.hpp"
-#include "vc/segmentation/ChainSegmentationAlgorithmBaseClass.hpp"
+#include "vc/segmentation/ChainSegmentationAlgorithm.hpp"
 #include "vc/segmentation/lrps/Common.hpp"
 #include "vc/segmentation/lrps/FittedCurve.hpp"
 
@@ -30,18 +30,26 @@ namespace volcart::segmentation
  *
  * @ingroup lrps
  */
-class LocalResliceSegmentation : public ChainSegmentationAlgorithmBaseClass
+class LocalResliceSegmentation : public ChainSegmentationAlgorithm
 {
 public:
-    /** @name Constructors */
-    /**@{*/
+    /** Pointer */
+    using Pointer = std::shared_ptr<LocalResliceSegmentation>;
+
     /** @brief Default constructor */
     LocalResliceSegmentation() = default;
+
     /** Default destructor */
     ~LocalResliceSegmentation() override = default;
-    /**@}*/
 
-    /**@{*/
+    /** Make a new shared instance */
+    template <typename... Args>
+    static auto New(Args... args) -> Pointer
+    {
+        return std::make_shared<LocalResliceSegmentation>(
+            std::forward<Args>(args)...);
+    }
+
     /** @brief Set the target z-index */
     void setTargetZIndex(int z) { endIndex_ = z; }
 
@@ -94,23 +102,18 @@ public:
     /** @brief Set whether to consider previous position as candidate position
      */
     void setConsiderPrevious(bool b) { considerPrevious_ = b; }
-    /**@}*/
 
-    /**@{*/
     /** @brief Compute the segmentation */
-    PointSet compute() override;
-    /**@}*/
+    auto compute() -> PointSet override;
 
-    /**@{*/
     /** Debug: Shows intensity maps in GUI window */
     void setVisualize(bool b) { visualize_ = b; }
 
     /** Debug: Dumps reslices and intensity maps to disk */
     void setDumpVis(bool b) { dumpVis_ = b; }
-    /**@}*/
 
     /** @brief Returns the maximum progress value */
-    size_t progressIterations() const override;
+    [[nodiscard]] auto progressIterations() const -> size_t override;
 
 private:
     /**
@@ -118,8 +121,8 @@ private:
      * @param currentCurve Input curve
      * @param index Index of point on curve
      */
-    cv::Vec3d estimate_normal_at_index_(
-        const FittedCurve& currentCurve, int index);
+    auto estimate_normal_at_index_(const FittedCurve& currentCurve, int index)
+        -> cv::Vec3d;
 
     /**
      * @brief Debug: Draw curve on slice image
@@ -128,15 +131,15 @@ private:
      * @param particleIndex Highlight point at particleIndex
      * @param showSpline Draw interpolated curve. Default only draws points
      */
-    cv::Mat draw_particle_on_slice_(
+    [[nodiscard]] auto draw_particle_on_slice_(
         const FittedCurve& curve,
         int sliceIndex,
         int particleIndex = -1,
-        bool showSpline = false) const;
+        bool showSpline = false) const -> cv::Mat;
 
     /** @brief Convert the internal storage array into a final PointSet */
-    PointSet create_final_pointset_(
-        const std::vector<std::vector<Voxel>>& points);
+    auto create_final_pointset_(const std::vector<std::vector<Voxel>>& points)
+        -> PointSet;
 
     /** Default minimum energy gradient */
     constexpr static double DEFAULT_MIN_ENERGY_GRADIENT = 1e-7;

--- a/segmentation/include/vc/segmentation/StructureTensorParticleSim.hpp
+++ b/segmentation/include/vc/segmentation/StructureTensorParticleSim.hpp
@@ -4,7 +4,7 @@
 
 #include <opencv2/core.hpp>
 
-#include "vc/segmentation/ChainSegmentationAlgorithmBaseClass.hpp"
+#include "vc/segmentation/ChainSegmentationAlgorithm.hpp"
 #include "vc/segmentation/stps/Particle.hpp"
 #include "vc/segmentation/stps/ParticleChain.hpp"
 
@@ -20,7 +20,7 @@ namespace volcart::segmentation
  *
  * @ingroup stps
  */
-class StructureTensorParticleSim : public ChainSegmentationAlgorithmBaseClass
+class StructureTensorParticleSim : public ChainSegmentationAlgorithm
 {
 public:
     /**@{*/


### PR DESCRIPTION
This makes it possible to swap chain segmentation algorithms in the VC GUI. The steps are as follow:

### Design your algorithm

Inherit from `volcart::segmentation::ChainSegmentationAlgorithm` and be sure to implement all of the required virtual functions:

```c++
class MyAlgorithm : public volcart::segmentation::ChainSegmentationAlgorithm
{
public:
    auto compute() -> PointSet override;
}
```

### Add your algorithm parameters to the segmentation parameters struct
```c++
// apps/VC/CWindow.hpp
// around line 58

    bool fIncludeMiddle;
    int targetIndex;
    int myParam;    // <--- new parameter
};
```

### Add your algorithm to the GUI algorithm selector dropdown
```c++
// apps/VC/CWindow.cpp - CWindow::CreateWidgets()
// around line 170 at the time of this writing

aSegMethodsComboBox->addItem(tr("My Algorithm"));
```

### Add your algorithm parameters to the GUI
```c++
// apps/VC/CWindow.cpp - CWindow::CreateWidgets()
// around line 215

// create the param widgets
// if you have multiple parameters, wrap them in a container widget
auto* myParam = new QSpinBox();

// connect your widgets so that they update `fSegParams`
// for complicated updates, modify CWindow::SetUpSegParams()
connect(myParam, &QSpinBox::valueChanged, [=](int v){fSegParams.myParam = v;});

// add the parameter(s) widget to the GUI
// at a minimum, you need to add an empty widget here
this->ui.segParamsStack->addWidget(myParam);
```

### Configure your algorithm when the user clicks Start
```c++
// apps/VC/CWindow.cpp
// at the top
#include "volcart/segmentation/MyAlgorithm.hpp"

// CWindow::DoSegmentation(), around line 553
else if (segIdx == 1) {    // <---- needs to match the index in the dropdown selector
  auto myAlgo = std::make_shared<MyAlgorithm>();
  myAlgo->setMyParam(fSegParams.myParam);
  segmenter = myAlgo;    // <---- assign to the base class pointer
}
```