### PR TITLE
(VC) Add basic keyboard shortcuts

### DIFF
--- a/apps/VC/CVolumeViewer.cpp
+++ b/apps/VC/CVolumeViewer.cpp
@@ -136,10 +136,20 @@ void CVolumeViewer::ScaleImage(double nFactor)
 }
 
 // Handle zoom in click
-void CVolumeViewer::OnZoomInClicked(void) { ScaleImage(1.25); }
+void CVolumeViewer::OnZoomInClicked(void)
+{
+    if (fZoomInBtn->isEnabled()) {
+        ScaleImage(1.25);
+    }
+}
 
 // Handle zoom out click
-void CVolumeViewer::OnZoomOutClicked(void) { ScaleImage(0.8); }
+void CVolumeViewer::OnZoomOutClicked(void)
+{
+    if (fZoomOutBtn->isEnabled()) {
+        ScaleImage(0.8);
+    }
+}
 
 // Handle reset click
 void CVolumeViewer::OnResetClicked(void)
@@ -154,14 +164,18 @@ void CVolumeViewer::OnResetClicked(void)
 void CVolumeViewer::OnNextClicked(void)
 {
     // send signal to controller (MVC) in order to update the content
-    SendSignalOnNextClicked();
+    if (fNextBtn->isEnabled()) {
+        SendSignalOnNextClicked();
+    }
 }
 
 // Handle previous image click
 void CVolumeViewer::OnPrevClicked(void)
 {
     // send signal to controller (MVC ) in order to update the content
-    SendSignalOnPrevClicked();
+    if (fPrevBtn->isEnabled()) {
+        SendSignalOnPrevClicked();
+    }
 }
 
 // Handle image index change

--- a/apps/VC/CVolumeViewer.hpp
+++ b/apps/VC/CVolumeViewer.hpp
@@ -34,7 +34,7 @@ protected:
     void mouseMoveEvent(QMouseEvent* event);
     void paintEvent(QPaintEvent* event);
 
-private slots:
+public slots:
     void OnZoomInClicked(void);
     void OnZoomOutClicked(void);
     void OnResetClicked(void);

--- a/apps/VC/CWindow.cpp
+++ b/apps/VC/CWindow.cpp
@@ -2,6 +2,7 @@
 // Chao Du 2014 Dec
 #include "CWindow.hpp"
 
+#include <QKeySequence>
 #include <QProgressBar>
 #include <QSettings>
 #include <opencv2/imgproc.hpp>
@@ -345,6 +346,39 @@ void CWindow::CreateWidgets(void)
 
     // Set up the status bar
     statusBar = this->findChild<QStatusBar*>("statusBar");
+
+    // setup shortcuts
+    slicePrev = new QShortcut(QKeySequence(tr("Left")), this);
+    sliceNext = new QShortcut(QKeySequence(tr("Right")), this);
+    sliceZoomIn = new QShortcut(QKeySequence::ZoomIn, this);
+    sliceZoomOut = new QShortcut(QKeySequence::ZoomOut, this);
+    impactDwn = new QShortcut(QKeySequence(tr("[")), this);
+    impactUp = new QShortcut(QKeySequence(tr("]")), this);
+
+    connect(
+        slicePrev, &QShortcut::activated, fVolumeViewerWidget,
+        &CVolumeViewerWithCurve::OnPrevClicked);
+    connect(
+        sliceNext, &QShortcut::activated, fVolumeViewerWidget,
+        &CVolumeViewerWithCurve::OnNextClicked);
+    connect(
+        sliceZoomIn, &QShortcut::activated, fVolumeViewerWidget,
+        &CVolumeViewerWithCurve::OnZoomInClicked);
+    connect(
+        sliceZoomOut, &QShortcut::activated, fVolumeViewerWidget,
+        &CVolumeViewerWithCurve::OnZoomOutClicked);
+    connect(impactUp, &QShortcut::activated, [this]() {
+        if (ui.sldImpactRange->isEnabled()) {
+            ui.sldImpactRange->triggerAction(
+                QSlider::SliderAction::SliderSingleStepAdd);
+        }
+    });
+    connect(impactDwn, &QShortcut::activated, [this]() {
+        if (ui.sldImpactRange->isEnabled()) {
+            ui.sldImpactRange->triggerAction(
+                QSlider::SliderAction::SliderSingleStepSub);
+        }
+    });
 }
 
 // Create menus
@@ -368,13 +402,18 @@ void CWindow::CreateActions(void)
 {
     fOpenVolAct = new QAction(tr("&Open volpkg..."), this);
     connect(fOpenVolAct, SIGNAL(triggered()), this, SLOT(Open()));
+    fOpenVolAct->setShortcut(QKeySequence::Open);
+
     fExitAct = new QAction(tr("E&xit..."), this);
     connect(fExitAct, SIGNAL(triggered()), this, SLOT(Close()));
+
     fAboutAct = new QAction(tr("&About..."), this);
     connect(fAboutAct, SIGNAL(triggered()), this, SLOT(About()));
+
     fSavePointCloudAct = new QAction(tr("&Save volpkg..."), this);
     connect(
         fSavePointCloudAct, SIGNAL(triggered()), this, SLOT(SavePointCloud()));
+    fSavePointCloudAct->setShortcut(QKeySequence::Save);
 }
 
 void CWindow::CreateBackend()

--- a/apps/VC/CWindow.hpp
+++ b/apps/VC/CWindow.hpp
@@ -5,6 +5,7 @@
 #include <QMessageBox>
 #include <QObject>
 #include <QRect>
+#include <QShortcut>
 #include <QSpinBox>
 #include <QThread>
 #include <QTimer>
@@ -217,6 +218,14 @@ private:
 
     QSlider* fEdtImpactRange;
     QLabel* fLabImpactRange;
+
+    // keyboard shortcuts
+    QShortcut* slicePrev;
+    QShortcut* sliceNext;
+    QShortcut* sliceZoomIn;
+    QShortcut* sliceZoomOut;
+    QShortcut* impactUp;
+    QShortcut* impactDwn;
 
     Ui_VCMainWindow ui;
 


### PR DESCRIPTION
Adds basic keyboard shortcuts:

- `Ctrl + O` - Open a .volpkg
- `Ctrl + S` - Save the .volpkg
- `Ctrl + +` - Zoom In
- `Ctrl + -` - Zoom Out
- `Left arrow key` - Previous slice
- `Right arrow key` - Next slice
- `[` - Impact slider down
- `]` - Impact slider up

This uses Qt's `QKeySequence` to detect keyboard inputs. As such, there are some things to note:
- On macOS, `Ctrl` is automatically replaced with `Cmd`
- Depending on your keyboard layout, you may have to somewhat modify the above commands. For example, my keyboard has the `+` key as a super to the `=` key, changing the Zoom In shortcut to `Ctrl + Shift + =`. Modifying the shortcuts for all keyboard layouts is not convenient or easy, so consider this a limitation.

Future updates will make these user-customizable.
 
Closes #14 