### PR TITLE
Add GH issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,0 +1,68 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: |
+        Tell us what you experienced!
+        
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Install using method...
+        2. Run this command...
+        3. See error...
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      placeholder: Please copy and paste the exact output of running vc_version.
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: How did you install the software?
+      options:
+        - Homebrew
+        - Docker
+        - Built from source
+  - type: checkboxes
+    id: operating-systems
+    attributes:
+      label: On which operating systems have you experienced this issue?
+      description: You may select more than one.
+      options:
+        - label: macOS
+        - label: Windows
+        - label: Linux
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant program output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/educelab/open-source-consortium/blob/main/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Volume Cartographer Discussions
+    url: https://github.com/educelab/volume-cartographer/discussions
+    about: Please ask and answer Volume Cartographer-related questions here.
+  - name: EduceLab OSC Discussions
+    url: https://github.com/orgs/educelab/discussions
+    about: Please ask and answer EduceLab OSC questions here.

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -169,6 +169,11 @@ add_executable(vc_repair_pointsets src/RepairPointSets.cpp)
 target_link_libraries(vc_repair_pointsets VC::core Boost::program_options)
 list(APPEND utils_install_list vc_repair_pointsets)
 
+# vc_fix_pointset_duplicates
+add_executable(vc_version src/ReportVersion.cpp)
+target_link_libraries(vc_version VC::core)
+list(APPEND utils_install_list vc_version)
+
 # Install targets
 if(VC_INSTALL_UTILS)
 install(

--- a/utils/src/ReportVersion.cpp
+++ b/utils/src/ReportVersion.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+
+#include "vc/core/Version.hpp"
+
+using namespace volcart;
+
+auto main() -> int
+{
+    std::cout << ProjectInfo::NameAndVersion();
+    std::cout << " (" << ProjectInfo::RepositoryHash() << ")\n";
+}


### PR DESCRIPTION
Also adds `vc_version` for reporting the Volume Cartographer version and git commit:

```shell
$ vc_version
volume-cartographer 2.25.0 (124b05a608b022cf3619b420dfe95cdd1e2fa520)
```