### PR TITLE
Update Linux instructions for running VC

### DIFF
--- a/docs/pages/running-gui-tools.md
+++ b/docs/pages/running-gui-tools.md
@@ -28,3 +28,8 @@
 ```shell
 docker run -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix ghcr.io/educelab/volume-cartographer VC
 ```
+
+If you get error `could not connect to display :<your display number>`, run this command first to allow Docker access to X before trying again:
+```shell
+xhost +local:docker
+```


### PR DESCRIPTION
Running VC as per [instructions](https://github.com/educelab/volume-cartographer/blob/develop/docs/pages/running-gui-tools.md#linux) resulted in this error message in my system:
```sh
$ docker run -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix ghcr.io/educelab/volume-cartographer VC
No protocol specified
qt.qpa.xcb: could not connect to display :0.0
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: minimalegl, minimal, linuxfb, eglfs, xcb, offscreen, vnc.
```

The command that fixed it for me is:
```sh
$ xhost +local:docker
non-network local connections being added to access control list
```

More thorough explanation is [here](https://unix.stackexchange.com/questions/177557/what-does-this-xhost-command-do), basically it allows docker to connect to X.

VC now works:
```sh
$ docker run -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix ghcr.io/educelab/volume-cartographer VC
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-root'
```
(GUI window is opened)

Feel free to either merge, ignore or change to your liking.