### PR TITLE
(vc_transform_mesh) Add the ability to load composite transforms

### DIFF
--- a/utils/src/TransformMesh.cpp
+++ b/utils/src/TransformMesh.cpp
@@ -3,12 +3,12 @@
 #include <boost/program_options.hpp>
 #include <itkAffineTransform.h>
 #include <itkCompositeTransform.h>
+#include <itkTransformFileReader.h>
 #include <itkTransformFileWriter.h>
 #include <itkTransformMeshFilter.h>
 
 #include "vc/core/filesystem.hpp"
-#include "vc/core/io/OBJReader.hpp"
-#include "vc/core/io/OBJWriter.hpp"
+#include "vc/core/io/MeshIO.hpp"
 
 namespace fs = volcart::filesystem;
 namespace po = boost::program_options;
@@ -21,6 +21,7 @@ using CompositeTransform = itk::CompositeTransform<double, 3>;
 using MeshTransformer =
     itk::TransformMeshFilter<vc::ITKMesh, vc::ITKMesh, CompositeTransform>;
 using TransformWriter = itk::TransformFileWriterTemplate<double>;
+using TransformReader = itk::TransformFileReaderTemplate<double>;
 
 int main(int argc, char** argv)
 {
@@ -34,6 +35,7 @@ int main(int argc, char** argv)
            "Input mesh file")
         ("output-mesh,o", po::value<std::string>()->required(),
            "Output mesh file")
+        ("input-tfm", po::value<std::string>(), "Input transformation file")
         ("output-tfm,t", po::value<std::string>(), "Output transformation file");
 
     po::options_description transformOpts("Transformations");
@@ -69,52 +71,57 @@ int main(int argc, char** argv)
     // Load mesh
     std::cout << "Loading mesh..." << std::endl;
     fs::path inputPath = parsed["input-mesh"].as<std::string>();
-    vc::io::OBJReader reader;
-    reader.setPath(inputPath);
-    auto mesh = reader.read();
+    auto meshGroup = vc::ReadMesh(inputPath);
+    auto mesh = meshGroup.mesh;
 
     // Setup composite transform
     auto compositeTrans = CompositeTransform::New();
 
+    // Load transform
+    if (parsed.count("input-tfm") > 0) {
+        fs::path tfmPath = parsed["input-tfm"].as<std::string>();
+        auto readTfm = TransformReader::New();
+        readTfm->SetFileName(tfmPath.string());
+        readTfm->Update();
+        auto it = readTfm->GetTransformList()->begin();
+        auto* tfm = static_cast<CompositeTransform*>((*it).GetPointer());
+        compositeTrans->AddTransform(tfm);
+    }
+
     // Build affine transform
-    auto affine = AffineTransform::New();
+    else {
+        auto affine = AffineTransform::New();
 
-    // Add translation
-    Displacement displacement;
-    displacement[0] = parsed["translate-x"].as<double>();
-    displacement[1] = parsed["translate-y"].as<double>();
-    displacement[2] = parsed["translate-z"].as<double>();
-    affine->Translate(displacement);
+        // Add translation
+        Displacement displacement;
+        displacement[0] = parsed["translate-x"].as<double>();
+        displacement[1] = parsed["translate-y"].as<double>();
+        displacement[2] = parsed["translate-z"].as<double>();
+        affine->Translate(displacement);
 
-    // Add scale
-    auto precompose = parsed.count("scale-precompose") > 0;
-    affine->Scale(parsed["scale"].as<double>(), precompose);
+        // Add scale
+        auto precompose = parsed.count("scale-precompose") > 0;
+        affine->Scale(parsed["scale"].as<double>(), precompose);
 
-    // Build composite transform
-    compositeTrans->AddTransform(affine);
+        // Build composite transform
+        compositeTrans->AddTransform(affine);
+    }
+
+    // Simplify the transform
+    compositeTrans->FlattenTransformQueue();
 
     // Apply the composite transform to the mesh
     std::cout << "Applying transform..." << std::endl;
-    auto output = vc::ITKMesh::New();
     auto transformer = MeshTransformer::New();
     transformer->SetInput(mesh);
-    transformer->SetOutput(output);
     transformer->SetTransform(compositeTrans);
     transformer->Update();
+    auto output = transformer->GetOutput();
 
     // Write the new mesh
     std::cout << "Writing mesh..." << std::endl;
     fs::path outputPath = parsed["output-mesh"].as<std::string>();
-    vc::io::OBJWriter writer;
-    writer.setPath(outputPath);
-    writer.setMesh(output);
-    try {
-        writer.setUVMap(reader.getUVMap());
-        writer.setTexture(reader.getTextureMat());
-    } catch (...) {
-        // Do nothing if there's no UV map or Texture image
-    }
-    writer.write();
+    vc::WriteMesh(outputPath, output, meshGroup.uv, meshGroup.texture);
 
     ///// Write the final transformations /////
     if (parsed.count("output-tfm") > 0) {


### PR DESCRIPTION
Adds the `--input-tfm` option for loading a `ITK::CompositeTransform` from file. Also updates the app to use `MeshIO` so we're not just limited to OBJ files.