### PR TITLE
Update CMake supported range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24..3.27 FATAL_ERROR)
 include(FetchContent)
 include(CMakeDependentOption)
 


### PR DESCRIPTION
Updates the CMake minimum required command to support a range. See [Modern CMake](https://cliutils.gitlab.io/modern-cmake/chapters/basics.html) for more details.