### PR TITLE
(OrientNormals) Also flip face normals

### DIFF
--- a/meshing/include/vc/meshing/OrientNormals.hpp
+++ b/meshing/include/vc/meshing/OrientNormals.hpp
@@ -13,6 +13,11 @@ namespace volcart::meshing
  * @class OrientNormals
  *
  * @brief Orient vertex normals towards a reference point.
+ *
+ * If vertex normals are flipped, the face normals are also flipped by
+ * reversing the winding order of all faces. This assumes that vertex normals
+ * were originally derived from the face normals and point in generally the
+ * same direction as the face normals.
  */
 class OrientNormals
 {

--- a/meshing/src/OrientNormals.cpp
+++ b/meshing/src/OrientNormals.cpp
@@ -1,5 +1,6 @@
 #include "vc/meshing/OrientNormals.hpp"
 
+#include "vc/core/util/Iteration.hpp"
 #include "vc/meshing/DeepCopy.hpp"
 
 using namespace volcart;
@@ -98,6 +99,14 @@ auto OrientNormals::compute() -> ITKMesh::Pointer
             output_->GetPointData(it.Index(), &normal);
             normal *= -1;
             output_->SetPointData(it.Index(), normal);
+        }
+
+        for (auto it = output_->GetCells()->Begin();
+             it != output_->GetCells()->End(); ++it) {
+            auto pointIds = it->Value()->GetPointIdsContainer().flip();
+            for (auto [localId, id] : enumerate(pointIds)) {
+                it->Value()->SetPointId(static_cast<int>(localId), id);
+            }
         }
     }
 


### PR DESCRIPTION
This is a follow-on to #48. If the vertex normals get flipped, also flip the face normals by reversing the face winding order. This leads to better automatic orientation of the UV map after flattening (#49). Here's an example from the En-Gedi scroll:

![auto-face-normals](https://github.com/educelab/volume-cartographer/assets/1434526/6d52fb68-d5c2-497b-8b6a-9e707560b31a)
