### PR TITLE
(PPM) Use custom TIFF reader for loading cell map

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -172,6 +172,7 @@ set(test_srcs
     test/LoggingTest.cpp
     test/SignalsTest.cpp
     test/IterationTest.cpp
+    test/TIFFIOTest.cpp
 )
 
 # Add a test executable for each src

--- a/core/include/vc/core/io/PointSetIO.hpp
+++ b/core/include/vc/core/io/PointSetIO.hpp
@@ -450,14 +450,11 @@ private:
 
         // Read data
         T t;
-        auto nbytes = header.dim * typeBytes;
+        std::size_t nbytes = header.width * header.dim * typeBytes;
+        std::vector<T> points(header.width, 0);
+        points.reserve(header.width);
         for (size_t h = 0; h < header.height; ++h) {
-            std::vector<T> points;
-            points.reserve(header.width);
-            for (size_t w = 0; w < header.width; ++w) {
-                infile.read(reinterpret_cast<char*>(t.val), nbytes);
-                points.push_back(t);
-            }
+            infile.read(reinterpret_cast<char*>(points.data()), nbytes);
             ps.pushRow(points);
         }
 

--- a/core/include/vc/core/io/TIFFIO.hpp
+++ b/core/include/vc/core/io/TIFFIO.hpp
@@ -60,8 +60,12 @@ enum class Compression {
  * WriteTIFF). Unless you need to read some obscure image type (e.g. 32-bit
  * float or signed integer images), it's generally preferable to use cv::imread.
  *
+ * If the raw size of the image (width x height x channels x bytes-per-sample)
+ * is >= 4GB, the TIFF will be written using the BigTIFF extension to the TIFF
+ * format.
+ *
  * @param path Path to TIFF file
- * @throws std::runtime_error Hard reading errors
+ * @throws std::runtime_error Unrecoverable read errors
  */
 auto ReadTIFF(const volcart::filesystem::path& path) -> cv::Mat;
 

--- a/core/include/vc/core/io/TIFFIO.hpp
+++ b/core/include/vc/core/io/TIFFIO.hpp
@@ -48,6 +48,17 @@ enum class Compression {
 };
 
 /**
+ * @brief Read a TIFF file
+ *
+ * Supports 8-bit and 16-bit integer types as well as 32-bit float types. This
+ * only supports single image TIFF files, so it's generally preferable to use
+ * something like cv::imread in most cases.
+ *
+ * @param path Path to TIFF file
+ */
+auto ReadTIFF(const volcart::filesystem::path& path) -> cv::Mat;
+
+/**
  * @brief Write a TIFF image to file
  *
  * Supports writing floating point and signed integer TIFFs, in addition to

--- a/core/include/vc/core/io/TIFFIO.hpp
+++ b/core/include/vc/core/io/TIFFIO.hpp
@@ -50,19 +50,30 @@ enum class Compression {
 /**
  * @brief Read a TIFF file
  *
- * Supports 8-bit and 16-bit integer types as well as 32-bit float types. This
- * only supports single image TIFF files, so it's generally preferable to use
- * something like cv::imread in most cases.
+ * Reads Gray, Gray+Alpha, RGB, and RGBA TIFF images. Supports 8, 16, and
+ * 32-bit integer types as well as 32-bit float types. 3 and 4 channel images
+ * will be returned with a BGR channel order, except for 8-bit and 16-bit
+ * signed integer types which will be returned with an RGB channel order.
+ *
+ * Only supports single image TIFF files with scanline encoding and a
+ * contiguous planar configuration (this matches the format written by
+ * WriteTIFF). Unless you need to read some obscure image type (e.g. 32-bit
+ * float or signed integer images), it's generally preferable to use cv::imread.
  *
  * @param path Path to TIFF file
+ * @throws std::runtime_error Hard reading errors
  */
 auto ReadTIFF(const volcart::filesystem::path& path) -> cv::Mat;
 
 /**
  * @brief Write a TIFF image to file
  *
- * Supports writing floating point and signed integer TIFFs, in addition to
- * unsigned 8 & 16 bit integer types. Also supports 1-4 channel images.
+ * Writes Gray, Gray+Alpha, RGB, and RGBA TIFF images. Supports 8, 16, and
+ * 32-bit integer types as well as 32-bit float types. 3 and 4 channel images
+ * are assumed to have a BGR channel order, except for 8-bit and 16-bit signed
+ * integer types which are not supported.
+ *
+ * @throws std::runtime_error All writing errors
  */
 void WriteTIFF(
     const volcart::filesystem::path& path,

--- a/core/src/PerPixelMap.cpp
+++ b/core/src/PerPixelMap.cpp
@@ -100,12 +100,18 @@ auto PerPixelMap::ReadPPM(const fs::path& path) -> PerPixelMap
     ppm.height_ = ppm.map_.height();
     ppm.width_ = ppm.map_.width();
 
-    ppm.mask_ = cv::imread(MaskPath(path).string(), cv::IMREAD_GRAYSCALE);
+    auto maskPath = MaskPath(path);
+    if (fs::exists(maskPath)) {
+        ppm.mask_ = cv::imread(maskPath.string(), cv::IMREAD_GRAYSCALE);
+    }
     if (ppm.mask_.empty()) {
         Logger()->warn("Failed to read mask: {}", MaskPath(path).string());
     }
 
-    ppm.cellMap_ = cv::imread(CellMapPath(path).string(), cv::IMREAD_UNCHANGED);
+    auto cellMapPath = CellMapPath(path);
+    if (fs::exists(cellMapPath)) {
+        ppm.cellMap_ = tiffio::ReadTIFF(cellMapPath);
+    }
     if (ppm.cellMap_.empty()) {
         Logger()->warn(
             "Failed to read cell map: {}", CellMapPath(path).string());

--- a/core/src/TIFFIO.cpp
+++ b/core/src/TIFFIO.cpp
@@ -98,9 +98,9 @@ auto tio::ReadTIFF(const volcart::filesystem::path& path) -> cv::Mat
     // Do channel conversion
     cv::Mat imgCopy;
     if (img.channels() == 3) {
-        cv::cvtColor(img, imgCopy, cv::COLOR_BGR2RGB);
+        cv::cvtColor(img, imgCopy, cv::COLOR_RGB2BGR);
     } else if (img.channels() == 4) {
-        cv::cvtColor(img, imgCopy, cv::COLOR_BGRA2RGBA);
+        cv::cvtColor(img, imgCopy, cv::COLOR_RGBA2BGRA);
     } else {
         imgCopy = img;
     }

--- a/core/test/PerPixelMapTest.cpp
+++ b/core/test/PerPixelMapTest.cpp
@@ -7,14 +7,24 @@ using namespace volcart;
 TEST(PerPixelMap, WriteRead)
 {
     // Build a PPM
-    PerPixelMap ppm(10, 10);
+    PerPixelMap ppm(100, 100);
+    cv::Mat mask = cv::Mat::zeros(100, 100, CV_8UC1);
+    cv::Mat cellMap = cv::Mat(100, 100, CV_32SC1);
+    cellMap = cv::Scalar::all(-1);
     for (auto y = 0; y < 10; ++y) {
         for (auto x = 0; x < 10; ++x) {
+            auto outY = 46 + y;
+            auto outX = 46 + x;
             auto dx = static_cast<double>(x);
             auto dy = static_cast<double>(y);
-            ppm(y, x) = {dx, dy, (dx + dy) / 2.0, dx, dy, (dx + dy) / 2.0};
+            ppm(outY, outX) = {dx, dy, (dx + dy) / 2.0,
+                               dx, dy, (dx + dy) / 2.0};
+            mask.at<std::uint8_t>(outY, outX) = 255U;
+            cellMap.at<std::int32_t>(outY, outX) = y + 10;
         }
     }
+    ppm.setMask(mask);
+    ppm.setCellMap(cellMap);
 
     // Write the PPM
     std::string path{"vc_core_PerPixelMap_WriteRead.ppm"};
@@ -25,9 +35,17 @@ TEST(PerPixelMap, WriteRead)
     EXPECT_NO_THROW(result = PerPixelMap::ReadPPM(path));
 
     // Test the values
-    for (auto y = 0; y < 10; ++y) {
-        for (auto x = 0; x < 10; ++x) {
+    for (auto y = 0; y < 100; ++y) {
+        for (auto x = 0; x < 100; ++x) {
             EXPECT_EQ(result(y, x), ppm(y, x));
         }
     }
+
+    // Test the mask
+    cv::Mat diff = ppm.mask() != result.mask();
+    EXPECT_EQ(cv::countNonZero(diff), 0);
+
+    // Test the cell map
+    diff = ppm.cellMap() != result.cellMap();
+    EXPECT_EQ(cv::countNonZero(diff), 0);
 }

--- a/core/test/TIFFIOTest.cpp
+++ b/core/test/TIFFIOTest.cpp
@@ -1,0 +1,533 @@
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <limits>
+
+#include <opencv2/core.hpp>
+
+#include "vc/core/io/TIFFIO.hpp"
+
+using namespace volcart::tiffio;
+namespace fs = volcart::filesystem;
+
+TEST(TIFFIO, WriteRead8UC1)
+{
+    using ElemT = std::uint8_t;
+    using PixelT = ElemT;
+    auto cvType = CV_8UC1;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, WriteRead8UC2)
+{
+    using ElemT = std::uint8_t;
+    using PixelT = cv::Vec<ElemT, 2>;
+    auto cvType = CV_8UC2;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, WriteRead8UC3)
+{
+    using ElemT = std::uint8_t;
+    using PixelT = cv::Vec<ElemT, 3>;
+    auto cvType = CV_8UC3;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, WriteRead8UC4)
+{
+    using ElemT = std::uint8_t;
+    using PixelT = cv::Vec<ElemT, 4>;
+    auto cvType = CV_8UC4;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, WriteRead8SC1)
+{
+    using ElemT = std::int8_t;
+    using PixelT = ElemT;
+    auto cvType = CV_8SC1;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, WriteRead8SC2)
+{
+    using ElemT = std::int8_t;
+    using PixelT = cv::Vec<ElemT, 2>;
+    auto cvType = CV_8SC2;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, Write8SC3)
+{
+    using ElemT = std::int8_t;
+    auto cvType = CV_8SC3;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
+    EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
+}
+
+TEST(TIFFIO, Write8SC4)
+{
+    using ElemT = std::int8_t;
+    auto cvType = CV_8SC4;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
+    EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
+}
+
+TEST(TIFFIO, WriteRead16UC1)
+{
+    using ElemT = std::uint16_t;
+    using PixelT = ElemT;
+    auto cvType = CV_16UC1;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, WriteRead16UC2)
+{
+    using ElemT = std::uint16_t;
+    using PixelT = cv::Vec<ElemT, 2>;
+    auto cvType = CV_16UC2;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, WriteRead16UC3)
+{
+    using ElemT = std::uint16_t;
+    using PixelT = cv::Vec<ElemT, 3>;
+    auto cvType = CV_16UC3;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, WriteRead16UC4)
+{
+    using ElemT = std::uint16_t;
+    using PixelT = cv::Vec<ElemT, 4>;
+    auto cvType = CV_16UC4;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, WriteRead16SC1)
+{
+    using ElemT = std::int16_t;
+    using PixelT = ElemT;
+    auto cvType = CV_16SC1;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, WriteRead16SC2)
+{
+    using ElemT = std::int16_t;
+    using PixelT = cv::Vec<ElemT, 2>;
+    auto cvType = CV_16SC2;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, Write16SC3)
+{
+    using ElemT = std::int16_t;
+    auto cvType = CV_16SC3;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
+    EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
+}
+
+TEST(TIFFIO, Write16SC4)
+{
+    using ElemT = std::int16_t;
+    auto cvType = CV_16SC4;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
+    EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
+}
+
+TEST(TIFFIO, WriteRead32SC1)
+{
+    using ElemT = std::int32_t;
+    using PixelT = ElemT;
+    auto cvType = CV_32SC1;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, WriteRead32SC2)
+{
+    using ElemT = std::int32_t;
+    using PixelT = cv::Vec<ElemT, 2>;
+    auto cvType = CV_32SC2;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, Write32SC3)
+{
+    using ElemT = std::int32_t;
+    auto cvType = CV_32SC3;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
+    EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
+}
+
+TEST(TIFFIO, Write32SC4)
+{
+    using ElemT = std::int32_t;
+    auto cvType = CV_32SC4;
+    auto low = std::numeric_limits<ElemT>::min();
+    auto high = std::numeric_limits<ElemT>::max();
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
+    EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
+}
+
+TEST(TIFFIO, WriteRead32FC1)
+{
+    using ElemT = std::float_t;
+    using PixelT = ElemT;
+    auto cvType = CV_32FC1;
+    auto low = 0.F;
+    auto high = 1.F;
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, WriteRead32FC2)
+{
+    using ElemT = std::float_t;
+    using PixelT = cv::Vec<ElemT, 2>;
+    auto cvType = CV_32FC2;
+    auto low = 0.F;
+    auto high = 1.F;
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, WriteRead32FC3)
+{
+    using ElemT = std::float_t;
+    using PixelT = cv::Vec<ElemT, 3>;
+    auto cvType = CV_32FC3;
+    auto low = 0.F;
+    auto high = 1.F;
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}
+
+TEST(TIFFIO, WriteRead32FC4)
+{
+    using ElemT = std::float_t;
+    using PixelT = cv::Vec<ElemT, 4>;
+    auto cvType = CV_32FC4;
+    auto low = 0.F;
+    auto high = 1.F;
+
+    cv::Mat img(10, 10, cvType);
+    cv::randu(img, low, high);
+
+    fs::path imgPath(
+        "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
+    WriteTIFF(imgPath, img);
+    auto result = ReadTIFF(imgPath);
+
+    EXPECT_EQ(result.size, img.size);
+    EXPECT_EQ(result.type(), img.type());
+
+    auto equal = std::equal(
+        result.begin<PixelT>(), result.end<PixelT>(), img.begin<PixelT>());
+    EXPECT_TRUE(equal);
+}

--- a/core/test/TIFFIOTest.cpp
+++ b/core/test/TIFFIOTest.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
-#include <iostream>
 #include <limits>
+#include <random>
 
 #include <opencv2/core.hpp>
 
@@ -10,18 +10,64 @@
 using namespace volcart::tiffio;
 namespace fs = volcart::filesystem;
 
+namespace
+{
+template <
+    typename Tp,
+    int Cn = 1,
+    std::enable_if_t<std::is_integral_v<Tp>, bool> = true>
+void FillRandom(
+    cv::Mat& mat,
+    Tp low = std::numeric_limits<Tp>::min(),
+    Tp high = std::numeric_limits<Tp>::max())
+{
+    using PixelT = cv::Vec<Tp, Cn>;
+    static std::random_device device;
+    static std::uniform_int_distribution<Tp> dist(low, high);
+    static std::default_random_engine gen(device());
+
+    std::generate(mat.begin<PixelT>(), mat.end<PixelT>(), []() {
+        PixelT pixel;
+        for (int i = 0; i < Cn; i++) {
+            pixel[i] = dist(gen);
+        }
+        return pixel;
+    });
+}
+
+template <
+    typename Tp,
+    int Cn = 1,
+    std::enable_if_t<std::is_floating_point_v<Tp>, bool> = true>
+void FillRandom(cv::Mat& mat, Tp low = 0, Tp high = 1)
+{
+    using PixelT = cv::Vec<Tp, Cn>;
+    static std::random_device device;
+    static std::uniform_real_distribution<Tp> dist(low, high);
+    static std::default_random_engine gen(device());
+
+    std::generate(mat.begin<PixelT>(), mat.end<PixelT>(), []() {
+        PixelT pixel;
+        for (int i = 0; i < Cn; i++) {
+            pixel[i] = dist(gen);
+        }
+        return pixel;
+    });
+}
+
+const cv::Size TEST_IMG_SIZE(10, 10);
+}  // namespace
+
 TEST(TIFFIO, WriteRead8UC1)
 {
     using ElemT = std::uint8_t;
     using PixelT = ElemT;
     auto cvType = CV_8UC1;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -39,13 +85,11 @@ TEST(TIFFIO, WriteRead8UC2)
     using ElemT = std::uint8_t;
     using PixelT = cv::Vec<ElemT, 2>;
     auto cvType = CV_8UC2;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 2>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -63,13 +107,11 @@ TEST(TIFFIO, WriteRead8UC3)
     using ElemT = std::uint8_t;
     using PixelT = cv::Vec<ElemT, 3>;
     auto cvType = CV_8UC3;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 3>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -87,13 +129,11 @@ TEST(TIFFIO, WriteRead8UC4)
     using ElemT = std::uint8_t;
     using PixelT = cv::Vec<ElemT, 4>;
     auto cvType = CV_8UC4;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 4>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -111,13 +151,11 @@ TEST(TIFFIO, WriteRead8SC1)
     using ElemT = std::int8_t;
     using PixelT = ElemT;
     auto cvType = CV_8SC1;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 1>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -135,13 +173,11 @@ TEST(TIFFIO, WriteRead8SC2)
     using ElemT = std::int8_t;
     using PixelT = cv::Vec<ElemT, 2>;
     auto cvType = CV_8SC2;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 2>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -158,13 +194,11 @@ TEST(TIFFIO, Write8SC3)
 {
     using ElemT = std::int8_t;
     auto cvType = CV_8SC3;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 3>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
     EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
 }
@@ -173,13 +207,11 @@ TEST(TIFFIO, Write8SC4)
 {
     using ElemT = std::int8_t;
     auto cvType = CV_8SC4;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 4>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
     EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
 }
@@ -189,13 +221,11 @@ TEST(TIFFIO, WriteRead16UC1)
     using ElemT = std::uint16_t;
     using PixelT = ElemT;
     auto cvType = CV_16UC1;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 1>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -213,13 +243,11 @@ TEST(TIFFIO, WriteRead16UC2)
     using ElemT = std::uint16_t;
     using PixelT = cv::Vec<ElemT, 2>;
     auto cvType = CV_16UC2;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 2>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -237,13 +265,11 @@ TEST(TIFFIO, WriteRead16UC3)
     using ElemT = std::uint16_t;
     using PixelT = cv::Vec<ElemT, 3>;
     auto cvType = CV_16UC3;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 3>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -261,13 +287,11 @@ TEST(TIFFIO, WriteRead16UC4)
     using ElemT = std::uint16_t;
     using PixelT = cv::Vec<ElemT, 4>;
     auto cvType = CV_16UC4;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 4>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -285,13 +309,11 @@ TEST(TIFFIO, WriteRead16SC1)
     using ElemT = std::int16_t;
     using PixelT = ElemT;
     auto cvType = CV_16SC1;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 1>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -309,13 +331,11 @@ TEST(TIFFIO, WriteRead16SC2)
     using ElemT = std::int16_t;
     using PixelT = cv::Vec<ElemT, 2>;
     auto cvType = CV_16SC2;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 2>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -332,13 +352,11 @@ TEST(TIFFIO, Write16SC3)
 {
     using ElemT = std::int16_t;
     auto cvType = CV_16SC3;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 3>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
     EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
 }
@@ -347,13 +365,11 @@ TEST(TIFFIO, Write16SC4)
 {
     using ElemT = std::int16_t;
     auto cvType = CV_16SC4;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 4>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
     EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
 }
@@ -363,13 +379,11 @@ TEST(TIFFIO, WriteRead32SC1)
     using ElemT = std::int32_t;
     using PixelT = ElemT;
     auto cvType = CV_32SC1;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 1>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -387,13 +401,11 @@ TEST(TIFFIO, WriteRead32SC2)
     using ElemT = std::int32_t;
     using PixelT = cv::Vec<ElemT, 2>;
     auto cvType = CV_32SC2;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 2>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -410,13 +422,11 @@ TEST(TIFFIO, Write32SC3)
 {
     using ElemT = std::int32_t;
     auto cvType = CV_32SC3;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 3>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
     EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
 }
@@ -425,13 +435,11 @@ TEST(TIFFIO, Write32SC4)
 {
     using ElemT = std::int32_t;
     auto cvType = CV_32SC4;
-    auto low = std::numeric_limits<ElemT>::min();
-    auto high = std::numeric_limits<ElemT>::max();
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 4>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
     EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
 }
@@ -441,13 +449,11 @@ TEST(TIFFIO, WriteRead32FC1)
     using ElemT = std::float_t;
     using PixelT = ElemT;
     auto cvType = CV_32FC1;
-    auto low = 0.F;
-    auto high = 1.F;
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 1>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -465,13 +471,11 @@ TEST(TIFFIO, WriteRead32FC2)
     using ElemT = std::float_t;
     using PixelT = cv::Vec<ElemT, 2>;
     auto cvType = CV_32FC2;
-    auto low = 0.F;
-    auto high = 1.F;
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 2>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -489,13 +493,11 @@ TEST(TIFFIO, WriteRead32FC3)
     using ElemT = std::float_t;
     using PixelT = cv::Vec<ElemT, 3>;
     auto cvType = CV_32FC3;
-    auto low = 0.F;
-    auto high = 1.F;
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 3>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);
@@ -513,13 +515,11 @@ TEST(TIFFIO, WriteRead32FC4)
     using ElemT = std::float_t;
     using PixelT = cv::Vec<ElemT, 4>;
     auto cvType = CV_32FC4;
-    auto low = 0.F;
-    auto high = 1.F;
 
-    cv::Mat img(10, 10, cvType);
-    cv::randu(img, low, high);
+    cv::Mat img(::TEST_IMG_SIZE, cvType);
+    ::FillRandom<ElemT, 4>(img);
 
-    fs::path imgPath(
+    const fs::path imgPath(
         "vc_core_TIFFIO_WriteRead_" + cv::typeToString(cvType) + ".tif");
     WriteTIFF(imgPath, img);
     auto result = ReadTIFF(imgPath);


### PR DESCRIPTION
This overhauls `TIFFIO.hpp` to fix some bugs and add new features:
- Added `tiffio::ReadTIFF` which can read single image, 8, 16, and 32bpc TIFF files with various pixel types.
- Added TIFFIO unit tests
- `tiffio::WriteTIFF` automatically write TIFFs > 4GB as BigTIFF.
- `tiffio::WriteTIFF` better handles obscure, unsupported color conversions (e.g. `CV_8SC3` and `CV_8SC4` are not supported by `cv::cvtColor`)
- (PerPixelMap) Use `tiffio::ReadTIFF` for loading the cell map (fixes #42)
- (PerPixelMap) Better error handling for mask and cell map loading
- (PPM Tests) Test mask and cell map serialization