### PR TITLE
Add keyboard shortcuts for zooming to GUI apps

### DIFF
--- a/app_support/include_gui_support/vc/gui_support/ImageScrollArea.hpp
+++ b/app_support/include_gui_support/vc/gui_support/ImageScrollArea.hpp
@@ -3,6 +3,7 @@
 #include <QGestureEvent>
 #include <QLabel>
 #include <QScrollArea>
+#include <QShortcut>
 #include <opencv2/core.hpp>
 
 namespace volcart::gui
@@ -22,6 +23,8 @@ public slots:
 
 private:
     QLabel* imageLabel_;
+    QShortcut* zoomIn_;
+    QShortcut* zoomOut_;
 
     double scaleFactor_;
 

--- a/app_support/src/ImageScrollArea.cpp
+++ b/app_support/src/ImageScrollArea.cpp
@@ -131,5 +131,15 @@ auto vcg::ImageScrollArea::event(QEvent* event) -> bool
     if (event->type() == QEvent::Gesture) {
         return gestureEvent(dynamic_cast<QGestureEvent*>(event));
     }
+    if (event->type() == QEvent::KeyPress) {
+        QKeyEvent* keyEvent = dynamic_cast<QKeyEvent*>(event);
+        if (keyEvent->key() == Qt::Key_Plus) {
+            this->zoom_in_();
+            return true;
+        } else if (keyEvent->key() == Qt::Key_Minus) {
+            this->zoom_out_();
+            return true;
+        }
+    }
     return QScrollArea::event(event);
 }

--- a/app_support/src/ImageScrollArea.cpp
+++ b/app_support/src/ImageScrollArea.cpp
@@ -1,6 +1,7 @@
 #include "vc/gui_support/ImageScrollArea.hpp"
 
 #include <QGuiApplication>
+#include <QKeySequence>
 #include <QMouseEvent>
 #include <QScrollBar>
 
@@ -16,6 +17,12 @@ vcg::ImageScrollArea::ImageScrollArea()
     setBackgroundRole(QPalette::Dark);
     setWidget(imageLabel_);
     verticalScrollBar()->installEventFilter(this);
+
+    zoomIn_ = new QShortcut(QKeySequence::ZoomIn, this);
+    zoomOut_ = new QShortcut(QKeySequence::ZoomOut, this);
+
+    connect(zoomIn_, &QShortcut::activated, this, &ImageScrollArea::zoom_in_);
+    connect(zoomOut_, &QShortcut::activated, this, &ImageScrollArea::zoom_out_);
 
     this->grabGesture(Qt::PinchGesture);
 }
@@ -130,16 +137,6 @@ auto vcg::ImageScrollArea::event(QEvent* event) -> bool
 {
     if (event->type() == QEvent::Gesture) {
         return gestureEvent(dynamic_cast<QGestureEvent*>(event));
-    }
-    if (event->type() == QEvent::KeyPress) {
-        QKeyEvent* keyEvent = dynamic_cast<QKeyEvent*>(event);
-        if (keyEvent->key() == Qt::Key_Plus) {
-            this->zoom_in_();
-            return true;
-        } else if (keyEvent->key() == Qt::Key_Minus) {
-            this->zoom_out_();
-            return true;
-        }
     }
     return QScrollArea::event(event);
 }


### PR DESCRIPTION
Adds '+' and '-' keyboard shortcuts to zoom in and out for apps that use ImageScrollArea. Helpful for more fine-grained zooming, in particular when scrolling is wonky, as when using a touchpad over remote desktop.