### PR TITLE
Fix includes and std:: namespace for fixed width integers and size_t

### DIFF
--- a/app_support/include_app_support/vc/app_support/GetMemorySize.hpp
+++ b/app_support/include_app_support/vc/app_support/GetMemorySize.hpp
@@ -15,5 +15,5 @@
 #include <cstddef>
 
 /** @brief Get the available system memory in bytes */
-size_t SystemMemorySize();
+std::size_t SystemMemorySize();
 // clang-format on

--- a/app_support/include_app_support/vc/app_support/ProgressIndicator.hpp
+++ b/app_support/include_app_support/vc/app_support/ProgressIndicator.hpp
@@ -3,6 +3,7 @@
 /** @file */
 
 #include <chrono>
+#include <cstddef>
 #include <iterator>
 #include <memory>
 
@@ -17,7 +18,7 @@ namespace volcart
  *
  * @ingroup Support
  */
-inline auto NewProgressBar(size_t maxProg, std::string label = "")
+inline auto NewProgressBar(std::size_t maxProg, std::string label = "")
 {
     using namespace indicators;
     namespace opt = option;
@@ -89,9 +90,9 @@ private:
         /** Shared progress bar instance */
         std::shared_ptr<indicators::ProgressBar> bar_;
         /** Current progress value */
-        size_t prog_{0};
+        std::size_t prog_{0};
         /** Max progress value */
-        size_t maxProg_{0};
+        std::size_t maxProg_{0};
         /** Use colors */
         bool useColors_{false};
         /** Last update timestamp */
@@ -102,7 +103,7 @@ private:
 
     public:
         /** @{ Iterator type traits */
-        using difference_type = size_t;
+        using difference_type = std::size_t;
         using value_type = typename std::iterator_traits<T>::value_type;
         using pointer = typename std::iterator_traits<T>::pointer;
         using reference = typename std::iterator_traits<T>::reference;
@@ -112,7 +113,7 @@ private:
         /** Constructor for the begin() iterator */
         explicit ConsoleProgressIterator(
             T beginIt,
-            size_t max,
+            std::size_t max,
             std::string label,
             bool useColors,
             std::chrono::steady_clock::duration interval =
@@ -219,8 +220,8 @@ public:
         auto begin = std::begin(container_);
         auto end = std::end(container_);
         return iterator{
-            begin, static_cast<size_t>(std::distance(begin, end)), cfg_.label,
-            cfg_.useColors};
+            begin, static_cast<std::size_t>(std::distance(begin, end)),
+            cfg_.label, cfg_.useColors};
     }
 
     /**

--- a/app_support/src/GetMemorySize.cpp
+++ b/app_support/src/GetMemorySize.cpp
@@ -8,6 +8,9 @@
 
 #include "vc/app_support/GetMemorySize.hpp"
 
+#include <cstdint>
+#include <cstddef>
+
 #if defined(_WIN32)
 #include <Windows.h>
 
@@ -25,7 +28,7 @@
 #endif
 
 /* Returns the size of physical memory (RAM) in bytes. */
-size_t SystemMemorySize()
+std::size_t SystemMemorySize()
 {
 
 #if defined(_WIN32) && (defined(__CYGWIN__) || defined(__CYGWIN32__))
@@ -34,7 +37,7 @@ size_t SystemMemorySize()
     MEMORYSTATUS status;
     status.dwLength = sizeof(status);
     GlobalMemoryStatus(&status);
-    return static_cast<size_t>(status.dwTotalPhys);
+    return static_cast<std::size_t>(status.dwTotalPhys);
 
 #elif defined(_WIN32)
     /* Windows. ------------------------------------------------- */
@@ -42,7 +45,7 @@ size_t SystemMemorySize()
     MEMORYSTATUSEX status;
     status.dwLength = sizeof(status);
     GlobalMemoryStatusEx(&status);
-    return static_cast<size_t>(status.ullTotalPhys);
+    return static_cast<std::size_t>(status.ullTotalPhys);
 
 #elif defined(__unix__) || defined(__unix) || defined(unix) || \
     (defined(__APPLE__) && defined(__MACH__))
@@ -57,27 +60,27 @@ size_t SystemMemorySize()
 #elif defined(HW_PHYSMEM64)
     mib[1] = HW_PHYSMEM64; /* NetBSD, OpenBSD. --------- */
 #endif
-    int64_t size = 0;    /* 64-bit */
-    size_t len = sizeof(size);
+    std::int64_t size = 0;    /* 64-bit */
+    std::size_t len = sizeof(size);
     if (sysctl(mib, 2, &size, &len, nullptr, 0) == 0) {
-        return static_cast<size_t>(size);
+        return static_cast<std::size_t>(size);
     }
     return 0L; /* Failed? */
 
 #elif defined(_SC_AIX_REALMEM)
     /* AIX. ----------------------------------------------------- */
-    return static_cast<size_t>(sysconf(_SC_AIX_REALMEM)) *
-           static_cast<size_t>(1024L);
+    return static_cast<std::size_t>(sysconf(_SC_AIX_REALMEM)) *
+           static_cast<std::size_t>(1024L);
 
 #elif defined(_SC_PHYS_PAGES) && defined(_SC_PAGESIZE)
     /* FreeBSD, Linux, OpenBSD, and Solaris. -------------------- */
-    return static_cast<size_t>(sysconf(_SC_PHYS_PAGES)) *
-           static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    return static_cast<std::size_t>(sysconf(_SC_PHYS_PAGES)) *
+           static_cast<std::size_t>(sysconf(_SC_PAGESIZE));
 
 #elif defined(_SC_PHYS_PAGES) && defined(_SC_PAGE_SIZE)
     /* Legacy. -------------------------------------------------- */
-    return static_cast<size_t>(sysconf(_SC_PHYS_PAGES)) *
-           static_cast<size_t>(sysconf(_SC_PAGE_SIZE));
+    return static_cast<std::size_t>(sysconf(_SC_PHYS_PAGES)) *
+           static_cast<std::size_t>(sysconf(_SC_PAGE_SIZE));
 
 #elif defined(CTL_HW) && (defined(HW_PHYSMEM) || defined(HW_REALMEM))
     /* DragonFly BSD, FreeBSD, NetBSD, OpenBSD, and OSX. -------- */
@@ -89,9 +92,9 @@ size_t SystemMemorySize()
     mib[1] = HW_PHYSMEM; /* Others. ------------------ */
 #endif
     unsigned int size = 0; /* 32-bit */
-    size_t len = sizeof(size);
+    std::size_t len = sizeof(size);
     if (sysctl(mib, 2, &size, &len, NULL, 0) == 0)
-        return static_cast<size_t>(size);
+        return static_cast<std::size_t>(size);
     return 0L; /* Failed? */
 #endif /* sysctl and sysconf variants */
 

--- a/apps/Canny/CannySegment.cpp
+++ b/apps/Canny/CannySegment.cpp
@@ -2,6 +2,7 @@
 #pragma ide diagnostic ignored "readability-identifier-length"
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma ide diagnostic ignored "cppcoreguidelines-avoid-magic-numbers"
+#include <cstdint>
 #include <iostream>
 #include <vector>
 
@@ -257,7 +258,7 @@ auto main(int argc, char* argv[]) -> int
             for (const auto pt : range2D(processed.rows, processed.cols)) {
                 const auto& x = pt.second;
                 const auto& y = pt.first;
-                if (processed.at<uint8_t>(y, x) > 0) {
+                if (processed.at<std::uint8_t>(y, x) > 0) {
                     middle = {
                         static_cast<double>(x), static_cast<double>(y),
                         static_cast<double>(z)};
@@ -397,7 +398,7 @@ auto main(int argc, char* argv[]) -> int
                 && yI < processed.rows
             ) {
                 // if point is on detected edge
-                if (!haveFirst && processed.at<uint8_t>(yI, xI) != 0) {
+                if (!haveFirst && processed.at<std::uint8_t>(yI, xI) != 0) {
                     // set first
                     first = {pt[0], pt[1], static_cast<double>(z)};
                     last = first;
@@ -405,7 +406,8 @@ auto main(int argc, char* argv[]) -> int
                     continue;
                 }
 
-                if (cannySettings.midpoint && haveFirst && processed.at<uint8_t>(yI, xI) != 0) {
+                if (cannySettings.midpoint && haveFirst &&
+                    processed.at<std::uint8_t>(yI, xI) != 0) {
                     last = {pt[0], pt[1], static_cast<double>(z)};
                 }
 

--- a/apps/Projection/Projection.hpp
+++ b/apps/Projection/Projection.hpp
@@ -2,12 +2,13 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma ide diagnostic ignored "cert-err58-cpp"
+#include <cstdint>
 
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
 
-static const double MAX_8BPC = std::numeric_limits<uint8_t>::max();
-static const double MAX_16BPC = std::numeric_limits<uint16_t>::max();
+static const double MAX_8BPC = std::numeric_limits<std::uint8_t>::max();
+static const double MAX_16BPC = std::numeric_limits<std::uint16_t>::max();
 
 static const cv::Scalar WHITE{255, 255, 255};
 static const cv::Scalar BLUE{255, 0, 0};

--- a/apps/VC/CBSpline.cpp
+++ b/apps/VC/CBSpline.cpp
@@ -32,7 +32,7 @@ void CBSpline::SetControlPoints(const std::vector<Vec2<double>>& nControlPoints)
         fCurveSegments.clear();
     }
 
-    for (size_t i = 0; i < nControlPoints.size(); ++i) {
+    for (std::size_t i = 0; i < nControlPoints.size(); ++i) {
         fControlPoints.push_back(nControlPoints[i]);
     }
 
@@ -54,7 +54,7 @@ void CBSpline::SetControlPoints(const std::vector<cv::Vec2f>& nControlPoints)
         fCurveSegments.clear();
     }
 
-    for (size_t i = 0; i < nControlPoints.size(); ++i) {
+    for (std::size_t i = 0; i < nControlPoints.size(); ++i) {
         fControlPoints.push_back(
             Vec2<double>(nControlPoints[i][0], nControlPoints[i][1]));
     }
@@ -67,7 +67,7 @@ void CBSpline::SetControlPoints(const std::vector<cv::Vec2f>& nControlPoints)
 // Get sample points
 void CBSpline::GetSamplePoints(std::vector<Vec2<double>>& nSamplePoints)
 {
-    for (size_t i = 0; i < fCurveSegments.size(); ++i) {
+    for (std::size_t i = 0; i < fCurveSegments.size(); ++i) {
         fCurveSegments[i].GetSamplePoints(nSamplePoints);
     }
 }
@@ -75,7 +75,7 @@ void CBSpline::GetSamplePoints(std::vector<Vec2<double>>& nSamplePoints)
 // Get sample points
 void CBSpline::GetSamplePoints(std::vector<cv::Vec2f>& nSamplePoints)
 {
-    for (size_t i = 0; i < fCurveSegments.size(); ++i) {
+    for (std::size_t i = 0; i < fCurveSegments.size(); ++i) {
         fCurveSegments[i].GetSamplePoints(nSamplePoints);
     }
 }
@@ -202,7 +202,7 @@ void CBSpline::DrawOnImage(cv::Mat& nImg, const cv::Scalar& nColor)
         return;
     }
 
-    for (size_t i = 0; i < fCurveSegments.size(); ++i) {
+    for (std::size_t i = 0; i < fCurveSegments.size(); ++i) {
         fCurveSegments[i].DrawOnImage(nImg, nColor);
     }
 }

--- a/apps/VC/CBSpline.hpp
+++ b/apps/VC/CBSpline.hpp
@@ -2,6 +2,7 @@
 // Chao Du 2015 April
 #pragma once
 
+#include <cstddef>
 #include <vector>
 
 #include <opencv2/core.hpp>
@@ -22,7 +23,10 @@ public:
     CBSpline(void);
     ~CBSpline(void);
 
-    size_t GetNumOfControlPoints(void) const { return fControlPoints.size(); }
+    std::size_t GetNumOfControlPoints(void) const
+    {
+        return fControlPoints.size();
+    }
     Vec2<double> GetPoint(int nIndex) const { return fControlPoints[nIndex]; }
 
     void SetControlPoints(const std::vector<Vec2<double>>& nControlPoints);

--- a/apps/VC/CVolumeViewerWithCurve.cpp
+++ b/apps/VC/CVolumeViewerWithCurve.cpp
@@ -2,6 +2,8 @@
 // Chao Du 2015 April
 #include "CVolumeViewerWithCurve.hpp"
 
+#include <cstddef>
+
 #include <QSettings>
 #include <opencv2/imgproc.hpp>
 
@@ -137,7 +139,7 @@ void CVolumeViewerWithCurve::UpdateView(void)
 
         // get primary color
         colorSelector->color().getRgb(&r, &g, &b);
-        for (size_t i = 0; i < fControlPoints.size(); ++i) {
+        for (std::size_t i = 0; i < fControlPoints.size(); ++i) {
             auto p = fControlPoints[i] - cv::Vec2f{0.5, 0.5};
             cv::circle(fImgMat, cv::Point2f(p), 1, cv::Scalar(b, g, r));
         }
@@ -303,7 +305,7 @@ int CVolumeViewerWithCurve::SelectPointOnCurve(
 {
     const double DIST_THRESHOLD = 1.5 * fScaleFactor;
 
-    for (size_t i = 0; i < nCurve->GetPointsNum(); ++i) {
+    for (std::size_t i = 0; i < nCurve->GetPointsNum(); ++i) {
         if (Norm<double>(Vec2<double>(
                 nCurve->GetPoint(i)[0] - nPt[0],
                 nCurve->GetPoint(i)[1] - nPt[1])) < DIST_THRESHOLD) {
@@ -321,7 +323,8 @@ void CVolumeViewerWithCurve::DrawIntersectionCurve(void)
         int g{0};
         int b{0};
         colorSelector->color().getRgb(&r, &g, &b);
-        for (size_t i = 0; i < fIntersectionCurveRef->GetPointsNum(); ++i) {
+        for (std::size_t i = 0; i < fIntersectionCurveRef->GetPointsNum();
+             ++i) {
             auto p0 = fIntersectionCurveRef->GetPoint(i)[0] - 0.5;
             auto p1 = fIntersectionCurveRef->GetPoint(i)[1] - 0.5;
             cv::circle(fImgMat, cv::Point2d(p0, p1), 1, cv::Scalar(b, g, r));

--- a/apps/VC/CWindow.cpp
+++ b/apps/VC/CWindow.cpp
@@ -431,7 +431,7 @@ void CWindow::CreateBackend()
     connect(
         worker, &VolPkgBackend::segmentationFailed, this,
         &CWindow::onSegmentationFailed);
-    connect(worker, &VolPkgBackend::progressUpdated, [=](size_t p) {
+    connect(worker, &VolPkgBackend::progressUpdated, [=](std::size_t p) {
         progress_ = p;
     });
     worker_thread_.start();
@@ -444,7 +444,7 @@ void CWindow::CreateBackend()
     progressBar_ = new QProgressBar();
     layout->addWidget(progressBar_);
     progressBar_->setMinimum(0);
-    connect(worker, &VolPkgBackend::segmentationStarted, [=](size_t its) {
+    connect(worker, &VolPkgBackend::segmentationStarted, [=](std::size_t its) {
         progressBar_->setMaximum(its);
     });
 
@@ -854,9 +854,9 @@ void CWindow::SetUpCurves(void)
     fMaxSegIndex = maxIndex;
 
     // assign rows of particles to the curves
-    for (size_t i = 0; i < fMasterCloud.height(); ++i) {
+    for (std::size_t i = 0; i < fMasterCloud.height(); ++i) {
         CXCurve aCurve;
-        for (size_t j = 0; j < fMasterCloud.width(); ++j) {
+        for (std::size_t j = 0; j < fMasterCloud.width(); ++j) {
             int pointIndex = j + (i * fMasterCloud.width());
             aCurve.SetSliceIndex(
                 static_cast<int>(floor(fMasterCloud[pointIndex][2])));
@@ -1385,7 +1385,7 @@ void CWindow::OnPathChanged(void)
         // update current slice
         fStartingPath.clear();
         cv::Vec3d tempPt;
-        for (size_t i = 0; i < fIntersectionCurve.GetPointsNum(); ++i) {
+        for (std::size_t i = 0; i < fIntersectionCurve.GetPointsNum(); ++i) {
             tempPt[0] = fIntersectionCurve.GetPoint(i)[0];
             tempPt[1] = fIntersectionCurve.GetPoint(i)[1];
             tempPt[2] = fPathOnSliceIndex;

--- a/apps/VC/CWindow.hpp
+++ b/apps/VC/CWindow.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+
 #include <QCloseEvent>
 #include <QComboBox>
 #include <QMessageBox>
@@ -236,7 +239,7 @@ private:
     QThread worker_thread_;
     BlockingDialog worker_progress_;
     QTimer worker_progress_updater_;
-    size_t progress_{0};
+    std::size_t progress_{0};
     QLabel* progressLabel_;
     QProgressBar* progressBar_;
 };  // class CWindow
@@ -250,16 +253,16 @@ public:
     explicit VolPkgBackend(QObject* parent = nullptr) : QObject(parent) {}
 
 signals:
-    void segmentationStarted(size_t);
+    void segmentationStarted(std::size_t);
     void segmentationFinished(Segmenter::PointSet ps);
     void segmentationFailed(std::string);
-    void progressUpdated(size_t);
+    void progressUpdated(std::size_t);
 
 public slots:
     void startSegmentation(Segmenter::Pointer segmenter)
     {
         segmenter->progressUpdated.connect(
-            [=](size_t p) { progressUpdated(p); });
+            [=](std::size_t p) { progressUpdated(p); });
         segmentationStarted(segmenter->progressIterations());
         try {
             auto result = segmenter->compute();

--- a/apps/VC/CXCurve.hpp
+++ b/apps/VC/CXCurve.hpp
@@ -19,7 +19,7 @@ public:
     void SetSliceIndex(int nIndex) { fSliceIndex = nIndex; }
     int GetSliceIndex(void) { return fSliceIndex; }
 
-    size_t GetPointsNum(void) const { return fPoints.size(); }
+    std::size_t GetPointsNum(void) const { return fPoints.size(); }
 
     Vec2<double> GetPoint(int nIndex) const { return fPoints[nIndex]; }
 

--- a/apps/VC/UDataManipulateUtils.cpp
+++ b/apps/VC/UDataManipulateUtils.cpp
@@ -1,5 +1,8 @@
 // UDataManipulateUtils.cpp
 // Chao Du 2014 Dec
+#include <cstddef>
+#include <cstdint>
+
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
 
@@ -40,13 +43,13 @@ bool SplitVertexAndElementBuffer(
 
     // iterate through every face (triangle), which is composed of 3 vertices,
     // and distribute to different arrays
-    size_t aSurfaceBase = 0;
-    size_t aArrayIndex = 0;
+    std::size_t aSurfaceBase = 0;
+    std::size_t aArrayIndex = 0;
 
     while (static_cast<int>(aSurfaceBase) < nFaceNum) {
 
-        size_t aSurfaceCntRemained = nFaceNum - aSurfaceBase;
-        size_t aSurfaceCntToProcess =
+        std::size_t aSurfaceCntRemained = nFaceNum - aSurfaceBase;
+        std::size_t aSurfaceCntToProcess =
             MAX_NUM_FACE_IN_ARRAY < aSurfaceCntRemained ? MAX_NUM_FACE_IN_ARRAY
                                                         : aSurfaceCntRemained;
 
@@ -65,13 +68,13 @@ bool SplitVertexAndElementBuffer(
         // REVISIT - *4 for padding, give w = 1
         (*nUVBufferSize)[aArrayIndex] = aSurfaceCntToProcess * 3 * 2;
 
-        for (size_t i = 0; i < aSurfaceCntToProcess; ++i) {
-            for (size_t j = 0; j < 3; ++j) {
+        for (std::size_t i = 0; i < aSurfaceCntToProcess; ++i) {
+            for (std::size_t j = 0; j < 3; ++j) {
 
                 // element array (vertex index)
                 int aVertexIndexNew = i * 3 + j;
                 (*nElementBufferData)[aArrayIndex][aVertexIndexNew] =
-                    static_cast<uint16_t>(aVertexIndexNew);
+                    static_cast<std::uint16_t>(aVertexIndexNew);
 
                 // REVISIT - IMPROVE - notice we don't deal with duplication of
                 // vertices, which is a big waste of memory space
@@ -123,8 +126,8 @@ QImage Mat2QImage(const cv::Mat& nSrc)
     cv::Mat tmp;
     cvtColor(nSrc, tmp, cv::COLOR_BGR2RGB);  // copy and convert color space
     QImage result(
-        static_cast<const uint8_t*>(tmp.data), tmp.cols, tmp.rows, tmp.step,
-        QImage::Format_RGB888);
+        static_cast<const std::uint8_t*>(tmp.data), tmp.cols, tmp.rows,
+        tmp.step, QImage::Format_RGB888);
     result.bits();  // enforce depp copy, see documentation of
     // QImage::QImage( const uchar *dta, int width, int height, Format format )
     return result;

--- a/apps/include/vc/apps/server/VolumeProtocol.hpp
+++ b/apps/include/vc/apps/server/VolumeProtocol.hpp
@@ -9,26 +9,26 @@ namespace volcart::protocol
  * Magic value that identifies this protocol on the wire. Generated with:
  * `echo -n Volume Protocol | md5sum | cut -c 1-8`
  */
-constexpr uint32_t MAGIC = 0xf6fcdac0;
+constexpr std::uint32_t MAGIC = 0xf6fcdac0;
 
 /** Size of a volpkg identifier. */
-constexpr uint32_t VOLPKG_SZ = 64;
+constexpr std::uint32_t VOLPKG_SZ = 64;
 
 /** Size of a volume identifier. */
-constexpr uint32_t VOLUME_SZ = 64;
+constexpr std::uint32_t VOLUME_SZ = 64;
 
 /** Enumeration of protocol versions. */
-enum Version : uint8_t { V1 = 1 };
+enum Version : std::uint8_t { V1 = 1 };
 
 // TODO: Add a request/response flag so that we can share a uniform prefix
 // header for all packets.
 
 /** Packet header for requests. */
 struct RequestHdr {
-    uint32_t magic{MAGIC};
+    std::uint32_t magic{MAGIC};
     Version version{Version::V1};
-    uint8_t pad[3];
-    uint32_t numRequests{0};
+    std::uint8_t pad[3];
+    std::uint32_t numRequests{0};
 };
 
 /** Packet structure for arguments to a given request. */
@@ -59,10 +59,10 @@ struct RequestArgs {
 struct ResponseArgs {
     char volpkg[VOLPKG_SZ];
     char volume[VOLUME_SZ];
-    uint32_t extentX;
-    uint32_t extentY;
-    uint32_t extentZ;
-    uint32_t size;
+    std::uint32_t extentX;
+    std::uint32_t extentY;
+    std::uint32_t extentZ;
+    std::uint32_t size;
 };
 
 }  // namespace volcart::protocol

--- a/apps/include/vc/apps/server/VolumeServer.hpp
+++ b/apps/include/vc/apps/server/VolumeServer.hpp
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QTcpServer>
 #include <QTcpSocket>
+#include <cstddef>
 #include <map>
 
 #include "vc/apps/server/VolumeProtocol.hpp"

--- a/apps/src/GeneratePPM.cpp
+++ b/apps/src/GeneratePPM.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+
 #include <boost/program_options.hpp>
 
 #include "vc/app_support/ProgressIndicator.hpp"
@@ -78,8 +80,9 @@ auto main(int argc, char* argv[]) -> int
         uvMap = abf.getUVMap();
     }
 
-    auto width = static_cast<size_t>(std::ceil(uvMap->ratio().width));
-    auto height = static_cast<size_t>(std::ceil(width / uvMap->ratio().aspect));
+    auto width = static_cast<std::size_t>(std::ceil(uvMap->ratio().width));
+    auto height =
+        static_cast<std::size_t>(std::ceil(width / uvMap->ratio().aspect));
 
     // PPM
     vc::Logger()->info("Generating per-pixel map");

--- a/apps/src/Packager.cpp
+++ b/apps/src/Packager.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 #include <limits>
 #include <regex>
@@ -27,8 +28,8 @@ enum class Flip { None, Horizontal, Vertical, ZFlip, Both, All };
 static const vci::ExtensionList ImageExts{"tif", "tiff", "png",
                                           "jpg", "jpeg", "bmp"};
 
-static const double MIN_16BPC = std::numeric_limits<uint16_t>::min();
-static const double MAX_16BPC = std::numeric_limits<uint16_t>::max();
+static const double MIN_16BPC = std::numeric_limits<std::uint16_t>::min();
+static const double MAX_16BPC = std::numeric_limits<std::uint16_t>::max();
 
 // Volpkg version required by this app
 static constexpr int VOLPKG_MIN_VERSION = 6;

--- a/apps/src/Render.cpp
+++ b/apps/src/Render.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include <unordered_map>
 
 #include <boost/program_options.hpp>
@@ -254,7 +256,7 @@ auto GetIntegralOpts() -> po::options_description
         ("expodiff-base", po::value<double>()->default_value(0.0), "If the "
             "base calculation method is set to Manual, the value from which "
             "voxel values are differenced.")
-        ("clamp-to-max", po::value<uint16_t>(), "Clamp values to the specified "
+        ("clamp-to-max", po::value<std::uint16_t>(), "Clamp values to the specified "
             "maximum.");
     // clang-format on
 
@@ -940,7 +942,7 @@ auto main(int argc, char* argv[]) -> int
         t->exponentialDiffBaseValue = expoDiffBase;
         t->clampValuesToMax = clampToMax;
         if (clampToMax) {
-            t->clampMax = parsed["clamp-to-max"].as<uint16_t>();
+            t->clampMax = parsed["clamp-to-max"].as<std::uint16_t>();
         }
         texturing = t;
     }

--- a/apps/src/RenderFromPPM.cpp
+++ b/apps/src/RenderFromPPM.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <sstream>
 
@@ -292,7 +294,7 @@ auto main(int argc, char* argv[]) -> int
         integral->setExponentialDiffBaseValue(expoDiffBase);
         integral->setClampValuesToMax(clampToMax);
         if (clampToMax) {
-            integral->setClampMax(parsed["clamp-to-max"].as<uint16_t>());
+            integral->setClampMax(parsed["clamp-to-max"].as<std::uint16_t>());
         }
         textureGen = integral;
     }

--- a/apps/src/RenderTexturing.cpp
+++ b/apps/src/RenderTexturing.cpp
@@ -1,5 +1,7 @@
 #include "vc/apps/render/RenderTexturing.hpp"
 
+#include <cstdint>
+
 #include <boost/program_options.hpp>
 
 namespace po = boost::program_options;
@@ -114,7 +116,7 @@ auto GetIntegralOpts() -> po::options_description
         ("expodiff-base", po::value<double>()->default_value(0.0), "If the "
             "base calculation method is set to Manual, the value from which "
             "voxel values are differenced.")
-        ("clamp-to-max", po::value<uint16_t>(), "Clamp values to the specified "
+        ("clamp-to-max", po::value<std::uint16_t>(), "Clamp values to the specified "
             "maximum.");
     // clang-format on
 

--- a/apps/src/Segment.cpp
+++ b/apps/src/Segment.cpp
@@ -1,4 +1,6 @@
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 
 #include <boost/program_options.hpp>
@@ -63,11 +65,11 @@ int main(int argc, char* argv[])
         ("volume", po::value<std::string>(),
             "Volume to use for texturing. Default: Segmentation's associated "
             "volume or the first volume in the volume package.")
-        ("start-index", po::value<size_t>(),
+        ("start-index", po::value<std::size_t>(),
             "Starting slice index. Default to highest z-index in path")
-        ("end-index", po::value<size_t>(),
+        ("end-index", po::value<std::size_t>(),
             "Ending slice index. Mutually exclusive with 'stride'")
-        ("stride", po::value<size_t>(),
+        ("stride", po::value<std::size_t>(),
             "Number of slices to propagate through relative to the starting slice index. "
             "Mutually exclusive with 'end-index'")
         ("step-size", po::value<double>()->default_value(kDefaultStep),
@@ -104,17 +106,17 @@ int main(int argc, char* argv[])
     // TFF options
     po::options_description tffOptions("Thinned Flood Fill Segmentation Options");
     tffOptions.add_options()
-        ("tff-low-thresh,l", po::value<uint16_t>()->default_value(14135),
+        ("tff-low-thresh,l", po::value<std::uint16_t>()->default_value(14135),
              "Low threshold for the bounded flood-fill component [0-65535]")
-        ("tff-high-thresh,t", po::value<uint16_t>()->default_value(65535),
+        ("tff-high-thresh,t", po::value<std::uint16_t>()->default_value(65535),
              "High threshold for the bounded flood-fill component [0-65535]")
         ("tff-dt-thresh", po::value<float>(),
              "Low threshold for the normalized distance transform [0-1]")
         ("closing-kernel-size,k", po::value<int>()->default_value(5),
              "Size of the kernel used for closing")
-        ("spur-length", po::value<size_t>()->default_value(6),
+        ("spur-length", po::value<std::size_t>()->default_value(6),
             "Spurs smaller than this size will be removed from the skeleton.")
-        ("max-seed-radius", po::value<size_t>(),
+        ("max-seed-radius", po::value<std::size_t>(),
             "Max radius a seed point can have when measuring the thickness of the page.")
         ("measure-vert", "Measure the thickness of the page by going vertically (+/- y) "
             "from each seed point (measures horizontally by default)")
@@ -223,7 +225,7 @@ int main(int argc, char* argv[])
     }
 
     // Set the cache size
-    size_t cacheBytes;
+    std::size_t cacheBytes;
     if (parsed.count("cache-memory-limit")) {
         auto cacheSizeOpt = parsed["cache-memory-limit"].as<std::string>();
         cacheBytes = vc::MemorySizeStringParser(cacheSizeOpt);
@@ -243,34 +245,34 @@ int main(int argc, char* argv[])
     // Get some info about the cloud, including chain length and z-index's
     // represented by seg.
     auto chainLength = masterCloud.width();
-    auto minIndex = static_cast<size_t>(floor(masterCloud.front()[2]));
-    auto maxIndex = static_cast<size_t>(floor(masterCloud.max()[2]));
+    auto minIndex = static_cast<std::size_t>(floor(masterCloud.front()[2]));
+    auto maxIndex = static_cast<std::size_t>(floor(masterCloud.max()[2]));
 
     // Cache arguments
     // If no start index is given, our starting path is all of the points
     // already on the largest slice index
-    size_t startIndex{0};
+    std::size_t startIndex{0};
     if (parsed.count("start-index") == 0) {
         startIndex = maxIndex;
         std::cout
             << "No starting index given. Defaulting to max Z in point set: "
             << startIndex << std::endl;
     } else {
-        startIndex = parsed["start-index"].as<size_t>();
+        startIndex = parsed["start-index"].as<std::size_t>();
     }
 
     // Step size
     auto step = parsed["step-size"].as<double>();
 
     // Figure out endIndex using either start-index or stride
-    size_t endIndex{0};
+    std::size_t endIndex{0};
     if (parsed.count("end-index") > 0) {
-        endIndex = parsed["end-index"].as<size_t>();
+        endIndex = parsed["end-index"].as<std::size_t>();
     } else if (parsed.count("stride") > 0) {
-        endIndex = startIndex + parsed["stride"].as<size_t>();
-        endIndex = std::min(endIndex, size_t(volume->numSlices() - 1));
+        endIndex = startIndex + parsed["stride"].as<std::size_t>();
+        endIndex = std::min(endIndex, std::size_t(volume->numSlices() - 1));
     } else {
-        endIndex = size_t(volume->numSlices() - 1);
+        endIndex = std::size_t(volume->numSlices() - 1);
         std::cout << "No end index given. Defaulting to max Z in volume: "
                   << endIndex << std::endl;
     }
@@ -288,7 +290,7 @@ int main(int argc, char* argv[])
     // Prepare our clouds
     // Get the upper, immutable cloud
     vc::OrderedPointSet<cv::Vec3d> immutableCloud;
-    size_t pathInCloudIndex = startIndex - minIndex;
+    std::size_t pathInCloudIndex = startIndex - minIndex;
     if (startIndex > minIndex) {
         immutableCloud = masterCloud.copyRows(0, pathInCloudIndex);
     } else {
@@ -360,16 +362,19 @@ int main(int argc, char* argv[])
         segmenter.setSeedPoints(segPath);
         segmenter.setVolume(volume);
         segmenter.setIterations(endIndex - startIndex + 1);
-        segmenter.setFFLowThreshold(parsed["tff-low-thresh"].as<uint16_t>());
-        segmenter.setFFHighThreshold(parsed["tff-high-thresh"].as<uint16_t>());
+        segmenter.setFFLowThreshold(
+            parsed["tff-low-thresh"].as<std::uint16_t>());
+        segmenter.setFFHighThreshold(
+            parsed["tff-high-thresh"].as<std::uint16_t>());
         if (parsed.count("tff-dt-thresh") > 0) {
             auto dtt = parsed["tff-dt-thresh"].as<float>();
             segmenter.setDistanceTransformThreshold(dtt);
         }
         segmenter.setClosingKernelSize(parsed["closing-kernel-size"].as<int>());
-        segmenter.setSpurLengthThreshold(parsed["spur-length"].as<size_t>());
+        segmenter.setSpurLengthThreshold(
+            parsed["spur-length"].as<std::size_t>());
         if (parsed.count("max-seed-radius") > 0) {
-            auto r = parsed["max-seed-radius"].as<size_t>();
+            auto r = parsed["max-seed-radius"].as<std::size_t>();
             segmenter.setMaxRadius(r);
         }
         segmenter.setMeasureVertical(parsed.count("measure-vert") > 0);

--- a/apps/src/SliceImage.cpp
+++ b/apps/src/SliceImage.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <limits>
 
 #include <opencv2/core.hpp>
@@ -8,7 +9,7 @@
 #include "vc/core/io/FileExtensionFilter.hpp"
 #include "vc/core/util/String.hpp"
 
-static const double MAX_16BPC = std::numeric_limits<uint16_t>::max();
+static const double MAX_16BPC = std::numeric_limits<std::uint16_t>::max();
 
 namespace volcart
 {

--- a/apps/src/VolumeClient.cpp
+++ b/apps/src/VolumeClient.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 
@@ -41,7 +42,7 @@ void vc::VolumeClient::newConnection()
     client_->write(
         reinterpret_cast<char*>(&requestHdr), sizeof(protocol::RequestHdr));
     client_->flush();
-    for (uint32_t i = 0; i < requestHdr.numRequests; i++) {
+    for (std::uint32_t i = 0; i < requestHdr.numRequests; i++) {
         // Neighborhood should be 27 with these settings
         protocol::RequestArgs requestArgs;
         std::memset(&requestArgs, 0, sizeof(requestArgs));
@@ -68,7 +69,7 @@ void vc::VolumeClient::newConnection()
     while (client_->waitForReadyRead()) {
         dataStream->startTransaction();
         bool abort = false;
-        for (uint32_t i = 0; i < requestHdr.numRequests; i++) {
+        for (std::uint32_t i = 0; i < requestHdr.numRequests; i++) {
             int bytesArgs = dataStream->readRawData(
                 reinterpret_cast<char*>(&responseArgs[i]),
                 sizeof(protocol::ResponseArgs));
@@ -89,7 +90,7 @@ void vc::VolumeClient::newConnection()
             break;
         }
     }
-    for (uint32_t i = 0; i < requestHdr.numRequests; i++) {
+    for (std::uint32_t i = 0; i < requestHdr.numRequests; i++) {
         vc::Logger()->info("=== Response: #{} ===", i);
         vc::Logger()->info("Volume Package: {}", responseArgs[i].volpkg);
         vc::Logger()->info("Volume: {}", responseArgs[i].volume);

--- a/apps/src/VolumeServer.cpp
+++ b/apps/src/VolumeServer.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 
 #include <QCoreApplication>
@@ -52,7 +54,7 @@ void vc::VolumeServer::socketReadyRead(QDataStream* dataStream)
     if (requestHdr.version != protocol::V1) {
         vc::Logger()->error(
             "{}: version is unsupported: {}", socketStr_(socket),
-            static_cast<uint32_t>(requestHdr.version));
+            static_cast<std::uint32_t>(requestHdr.version));
         // TODO: actually exit
     }
     vc::Logger()->info(
@@ -77,7 +79,7 @@ void vc::VolumeServer::socketReadyRead(QDataStream* dataStream)
         return;
     }
     // Resolve requests
-    for (uint32_t i = 0; i < requestHdr.numRequests; i++) {
+    for (std::uint32_t i = 0; i < requestHdr.numRequests; i++) {
         resolveRequest_(socket, &requestArgs[i]);
     }
     // Clean up
@@ -163,15 +165,15 @@ void vc::VolumeServer::resolveRequest_(
         subvolume.compute(volume, center, {zvec, yvec, xvec});
     vc::Logger()->info("{}: Subvolume generated...", socketStr_(socket));
     responseArgs.size =
-        static_cast<uint32_t>(neighborhood.size() * sizeof(uint16_t));
+        static_cast<std::uint32_t>(neighborhood.size() * sizeof(uint16_t));
     auto extents = neighborhood.extents();
-    responseArgs.extentX = static_cast<uint32_t>(extents[2]);
-    responseArgs.extentY = static_cast<uint32_t>(extents[1]);
-    responseArgs.extentZ = static_cast<uint32_t>(extents[0]);
+    responseArgs.extentX = static_cast<std::uint32_t>(extents[2]);
+    responseArgs.extentY = static_cast<std::uint32_t>(extents[1]);
+    responseArgs.extentZ = static_cast<std::uint32_t>(extents[0]);
     socket->write(
         reinterpret_cast<char*>(&responseArgs), sizeof(protocol::ResponseArgs));
     socket->write(
         reinterpret_cast<char*>(neighborhood.data()),
-        sizeof(uint16_t) * neighborhood.size());
+        sizeof(std::uint16_t) * neighborhood.size());
     socket->flush();
 }

--- a/apps/src/VolumeServerApp.cpp
+++ b/apps/src/VolumeServerApp.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <iostream>
 
 #include <boost/program_options.hpp>
@@ -58,7 +59,7 @@ int main(int argc, char* argv[])
 
     // Get the memory to reserve
     std::string memoryString = parsed["memory"].as<std::string>();
-    size_t memory = 0;
+    std::size_t memory = 0;
     try {
         memory = vc::MemorySizeStringParser(memoryString);
         if (memory > SystemMemorySize()) {

--- a/cmake/Buildsmgl.cmake
+++ b/cmake/Buildsmgl.cmake
@@ -1,7 +1,7 @@
 FetchContent_Declare(
     smgl
     GIT_REPOSITORY https://gitlab.com/educelab/smgl.git
-    GIT_TAG v0.10.0
+    GIT_TAG v0.10.1
     CMAKE_CACHE_ARGS
         -DSMGL_BUILD_JSON:BOOL=ON
         -DSMGL_USE_BOOSTFS:BOOL=ON

--- a/core/include/vc/core/Version.hpp
+++ b/core/include/vc/core/Version.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstdint>
 #include <string>
 
 namespace volcart
@@ -16,11 +17,11 @@ struct ProjectInfo {
     /** Get the library name and version string */
     static auto NameAndVersion() -> std::string;
     /** Get the library Major version number */
-    static auto VersionMajor() -> uint32_t;
+    static auto VersionMajor() -> std::uint32_t;
     /** Get the library Minor version number */
-    static auto VersionMinor() -> uint32_t;
+    static auto VersionMinor() -> std::uint32_t;
     /** Get the library Patch version number */
-    static auto VersionPatch() -> uint32_t;
+    static auto VersionPatch() -> std::uint32_t;
     /** Get the git repository URL */
     static auto RepositoryURL() -> std::string;
     /** Get the full hash for the current git commit */

--- a/core/include/vc/core/io/FileExtensionFilter.hpp
+++ b/core/include/vc/core/io/FileExtensionFilter.hpp
@@ -23,7 +23,7 @@ inline bool FileExtensionFilter(
     const volcart::filesystem::path& path, const ExtensionList& exts)
 {
     std::string regexExpression = ".*\\.(";
-    size_t count = 0;
+    std::size_t count = 0;
     for (const auto& e : exts) {
         regexExpression.append(e);
         if (++count < exts.size()) {

--- a/core/include/vc/core/io/OBJWriter.hpp
+++ b/core/include/vc/core/io/OBJWriter.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 
@@ -98,7 +99,7 @@ private:
      * vt = UV coordinate index number \n
      * vn = vertex normal index number \n
      */
-    std::map<uint32_t, cv::Vec3i> pointLinks_;
+    std::map<std::uint32_t, cv::Vec3i> pointLinks_;
 
     /** Input mesh */
     ITKMesh::Pointer mesh_;

--- a/core/include/vc/core/io/PLYWriter.hpp
+++ b/core/include/vc/core/io/PLYWriter.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstdint>
 #include <fstream>
 
 #include <opencv2/core.hpp>
@@ -60,7 +61,7 @@ public:
     void setTexture(cv::Mat texture);
 
     /** @brief Set per-vertex color information */
-    void setVertexColors(const std::vector<uint16_t>& c);
+    void setVertexColors(const std::vector<std::uint16_t>& c);
     /**@}*/
 
     /**@{*/
@@ -85,7 +86,7 @@ private:
     /** Input texture image */
     cv::Mat texture_;
     /** Vertex colors */
-    std::vector<uint16_t> vcolors_;
+    std::vector<std::uint16_t> vcolors_;
 
     /** @brief Write the PLY header */
     auto write_header_() -> int;

--- a/core/include/vc/core/io/PointSetIO.hpp
+++ b/core/include/vc/core/io/PointSetIO.hpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <fstream>
 #include <regex>
 #include <sstream>
@@ -45,10 +46,10 @@ class PointSetIO
 public:
     /** @brief PointSet file header information */
     struct Header {
-        size_t width{0};
-        size_t height{0};
-        size_t size{0};
-        size_t dim{0};
+        std::size_t width{0};
+        std::size_t height{0};
+        std::size_t size{0};
+        std::size_t dim{0};
         bool ordered{false};
         std::string type;
     };
@@ -350,9 +351,9 @@ private:
         auto header = PointSetIO<T>::ParseHeader(infile, false);
         PointSet<T> ps{header.size};
 
-        for (size_t i = 0; i < header.size; ++i) {
+        for (std::size_t i = 0; i < header.size; ++i) {
             std::array<typename T::value_type, T::channels> values;
-            for (size_t d = 0; d < header.dim; ++d) {
+            for (std::size_t d = 0; d < header.dim; ++d) {
                 infile >> values[d];
             }
             ps.push_back(T{values.data()});
@@ -377,10 +378,10 @@ private:
 
         std::vector<T> points;
         points.reserve(header.width);
-        for (size_t h = 0; h < header.height; ++h) {
-            for (size_t w = 0; w < header.width; ++w) {
+        for (std::size_t h = 0; h < header.height; ++h) {
+            for (std::size_t w = 0; w < header.width; ++w) {
                 std::array<typename T::value_type, T::channels> values;
-                for (size_t d = 0; d < header.dim; ++d) {
+                for (std::size_t d = 0; d < header.dim; ++d) {
                     infile >> values.at(d);
                 }
                 points.emplace_back(values.data());
@@ -404,7 +405,7 @@ private:
         PointSet<T> ps{header.size};
 
         // Size of binary elements to read
-        size_t typeBytes{};
+        std::size_t typeBytes{};
         if (header.type == "float") {
             typeBytes = sizeof(float);
         } else if (header.type == "double") {
@@ -415,7 +416,7 @@ private:
 
         // Read data
         T t;
-        for (size_t i = 0; i < header.size; ++i) {
+        for (std::size_t i = 0; i < header.size; ++i) {
             auto nbytes = header.dim * typeBytes;
             infile.read(reinterpret_cast<char*>(t.val), nbytes);
             ps.push_back(t);
@@ -437,7 +438,7 @@ private:
         OrderedPointSet<T> ps{header.width};
 
         // Size of binary elements to read
-        size_t typeBytes = sizeof(int);
+        std::size_t typeBytes = sizeof(int);
         if (header.type == "float") {
             typeBytes = sizeof(float);
         } else if (header.type == "double") {
@@ -454,7 +455,7 @@ private:
         std::size_t nbytes = header.width * header.dim * typeBytes;
         std::vector<T> points(header.width, 0);
         points.reserve(header.width);
-        for (size_t h = 0; h < header.height; ++h) {
+        for (std::size_t h = 0; h < header.height; ++h) {
             infile.read(reinterpret_cast<char*>(points.data()), nbytes);
             ps.pushRow(points);
         }
@@ -477,7 +478,7 @@ private:
         auto header = PointSetIO<T>::MakeHeader(ps);
         outfile << header;
         for (const auto& p : ps) {
-            for (size_t i = 0; i < T::channels; ++i) {
+            for (std::size_t i = 0; i < T::channels; ++i) {
                 outfile << p(i) << " ";
             }
             outfile << std::endl;
@@ -530,7 +531,7 @@ private:
         auto header = PointSetIO<T>::MakeOrderedHeader(ps);
         outfile << header;
         for (const auto& p : ps) {
-            for (size_t i = 0; i < T::channels; ++i) {
+            for (std::size_t i = 0; i < T::channels; ++i) {
                 outfile << p(i) << " ";
             }
             outfile << std::endl;

--- a/core/include/vc/core/math/StructureTensor.hpp
+++ b/core/include/vc/core/math/StructureTensor.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <opencv2/core.hpp>
 
 #include "vc/core/math/Tensor3D.hpp"
@@ -140,14 +142,16 @@ template <typename DType>
 Tensor3D<DType> ComputeVoxelNeighbors(
     const Volume::Pointer& volume,
     const cv::Vec3i& center,
-    int32_t rx,
-    int32_t ry,
-    int32_t rz)
+    std::int32_t rx,
+    std::int32_t ry,
+    std::int32_t rz)
 {
     Tensor3D<DType> v(2 * rx + 1, 2 * ry + 1, 2 * rz + 1);
-    for (int32_t k = center(2) - rz, c = 0; k <= center(2) + rz; ++k, ++c) {
-        for (int32_t j = center(1) - ry, b = 0; j <= center(1) + ry; ++j, ++b) {
-            for (int32_t i = center(0) - rx, a = 0; i <= center(0) + rx;
+    for (std::int32_t k = center(2) - rz, c = 0; k <= center(2) + rz;
+         ++k, ++c) {
+        for (std::int32_t j = center(1) - ry, b = 0; j <= center(1) + ry;
+             ++j, ++b) {
+            for (std::int32_t i = center(0) - rx, a = 0; i <= center(0) + rx;
                  ++i, ++a) {
                 v(a, b, c) = DType(volume->intensityAt(i, j, k));
             }

--- a/core/include/vc/core/math/Tensor3D.hpp
+++ b/core/include/vc/core/math/Tensor3D.hpp
@@ -7,6 +7,7 @@
  */
 
 #include <cassert>
+#include <cstddef>
 #include <memory>
 #include <vector>
 
@@ -37,7 +38,8 @@ public:
      * @param z The size of the Z-axis
      * @param zero If true, initialize the Tensor with zeroes
      */
-    Tensor3D<DType>(size_t x, size_t y, size_t z, bool zero = true)
+    Tensor3D<DType>(
+        std::size_t x, std::size_t y, std::size_t z, bool zero = true)
         : dx_(x), dy_(y), dz_(z)
     {
         tensor_.reserve(dz_);
@@ -47,11 +49,11 @@ public:
             // Static vars are automatically initialized to zero, so it's a
             // convenient way to zero-initialize the tensor
             static DType d;
-            for (size_t i = 0; i < dz_; ++i) {
+            for (std::size_t i = 0; i < dz_; ++i) {
                 tensor_.emplace_back(dy_, dx_, d);
             }
         } else {
-            for (size_t i = 0; i < dz_; ++i) {
+            for (std::size_t i = 0; i < dz_; ++i) {
                 tensor_.emplace_back(dy_, dx_);
             }
         }
@@ -61,7 +63,7 @@ public:
     /**@{*/
     /** @brief Get the tensor value at x, y, z
      */
-    const DType& operator()(size_t x, size_t y, size_t z) const
+    const DType& operator()(std::size_t x, std::size_t y, std::size_t z) const
     {
         assert(x < dx_ && x >= 0 && "index out of range");
         assert(y < dy_ && y >= 0 && "index out of range");
@@ -70,7 +72,7 @@ public:
     }
 
     /** @copydoc operator()() */
-    DType& operator()(size_t x, size_t y, size_t z)
+    DType& operator()(std::size_t x, std::size_t y, std::size_t z)
     {
         assert(x < dx_ && x >= 0 && "index out of range");
         assert(y < dy_ && y >= 0 && "index out of range");
@@ -81,36 +83,36 @@ public:
 
     /**@{*/
     /** @brief Get the size of the X-axis */
-    size_t dx() { return dx_; }
+    std::size_t dx() { return dx_; }
 
     /** @copydoc dx() */
-    size_t dx() const { return dx_; }
+    std::size_t dx() const { return dx_; }
 
     /** @brief Get the size of the Y-axis */
-    size_t dy() { return dy_; }
+    std::size_t dy() { return dy_; }
 
     /** @copydoc dy() */
-    size_t dy() const { return dy_; }
+    std::size_t dy() const { return dy_; }
 
     /** @brief Get the size of the Z-axis */
-    size_t dz() { return dz_; }
+    std::size_t dz() { return dz_; }
 
     /** @copydoc dz() */
-    size_t dz() const { return dz_; }
+    std::size_t dz() const { return dz_; }
     /**@}*/
 
     /**@{*/
     /** @brief Get an XY cross section of the Tensor at z */
-    const cv::Mat_<DType>& xySlice(size_t z) const { return tensor_[z]; }
+    const cv::Mat_<DType>& xySlice(std::size_t z) const { return tensor_[z]; }
 
     /** @copydoc xySlice() */
-    cv::Mat_<DType>& xySlice(size_t z) { return tensor_[z]; }
+    cv::Mat_<DType>& xySlice(std::size_t z) { return tensor_[z]; }
 
     /** @brief Get an XZ cross section of the Tensor at y */
-    cv::Mat_<DType> xzSlice(size_t y) const
+    cv::Mat_<DType> xzSlice(std::size_t y) const
     {
         cv::Mat_<DType> zSlice(dz_, dx_);
-        for (size_t z = 0; z < dz_; ++z) {
+        for (std::size_t z = 0; z < dz_; ++z) {
             tensor_[z].row(y).copyTo(zSlice.row(z));
         }
         return zSlice;
@@ -122,9 +124,9 @@ public:
     std::unique_ptr<DType[]> buffer() const
     {
         auto buf = std::make_unique<DType[]>(dx_ * dy_ * dz_);
-        for (size_t z = 0; z < dz_; ++z) {
-            for (size_t y = 0; y < dy_; ++y) {
-                for (size_t x = 0; x < dx_; ++x) {
+        for (std::size_t z = 0; z < dz_; ++z) {
+            for (std::size_t y = 0; y < dy_; ++y) {
+                for (std::size_t x = 0; x < dx_; ++x) {
                     buf[z * dx_ * dy_ + y * dx_ + x] = tensor_[z](y, x);
                 }
             }
@@ -137,11 +139,11 @@ private:
     /** Tensor storage */
     std::vector<cv::Mat_<DType>> tensor_;
     /** Size of the X-axis */
-    size_t dx_;
+    std::size_t dx_;
     /** Size of the Y-axis */
-    size_t dy_;
+    std::size_t dy_;
     /** Size of the Z-axis */
-    size_t dz_;
+    std::size_t dz_;
 };
 }  // namespace volcart
 
@@ -153,7 +155,7 @@ template <typename DType>
 std::ostream& operator<<(
     std::ostream& s, const volcart::Tensor3D<DType>& tensor)
 {
-    for (size_t z = 0; z < tensor.dz_; ++z) {
+    for (std::size_t z = 0; z < tensor.dz_; ++z) {
         s << tensor.xySlice(z) << std::endl;
     }
     return s;

--- a/core/include/vc/core/neighborhood/NeighborhoodGenerator.hpp
+++ b/core/include/vc/core/neighborhood/NeighborhoodGenerator.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 
 #include "vc/core/types/NDArray.hpp"
@@ -15,7 +17,7 @@ namespace volcart
  *
  * @ingroup Neighborhoods
  */
-using Neighborhood = NDArray<uint16_t>;
+using Neighborhood = NDArray<std::uint16_t>;
 
 /**
  * @brief Neighborhood directional filtering options
@@ -42,7 +44,7 @@ public:
 
     /**@{*/
     /** @brief Get the dimensionality of the neighborhood generator */
-    size_t dim() { return dim_; }
+    std::size_t dim() { return dim_; }
 
     /** @brief Get the size of the neighborhood returned by this class
      *
@@ -54,7 +56,10 @@ public:
 
     /**@{*/
     /** @brief Set the sampling search radius by axis */
-    void setSamplingRadius(double r, size_t axis = 0) { radius_[axis] = r; }
+    void setSamplingRadius(double r, std::size_t axis = 0)
+    {
+        radius_[axis] = r;
+    }
 
     /** @brief Set the sampling search radius for all axes */
     void setSamplingRadius(double r0, double r1, double r2)
@@ -98,12 +103,12 @@ public:
 
 protected:
     /** Default constructor */
-    explicit NeighborhoodGenerator(size_t dim) : dim_{dim} {}
+    explicit NeighborhoodGenerator(std::size_t dim) : dim_{dim} {}
 
     virtual ~NeighborhoodGenerator() = default;
 
     /** Dimensionality of the generator */
-    const size_t dim_{0};
+    const std::size_t dim_{0};
 
     /** Radius of calculation */
     cv::Vec3d radius_{1.0, 1.0, 1.0};

--- a/core/include/vc/core/shapes/Cone.hpp
+++ b/core/include/vc/core/shapes/Cone.hpp
@@ -3,6 +3,7 @@
 /** @file */
 
 #include <cmath>
+#include <cstddef>
 
 #include <opencv2/core.hpp>
 

--- a/core/include/vc/core/shapes/ShapePrimitive.hpp
+++ b/core/include/vc/core/shapes/ShapePrimitive.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 #include <opencv2/core.hpp>
 #include <vtkCellArray.h>
 #include <vtkCellData.h>
@@ -90,10 +92,10 @@ public:
     bool isOrdered() const { return ordered_; }
 
     /** @brief Return the width of the ordered vertex set */
-    size_t orderedWidth() const { return orderedWidth_; }
+    std::size_t orderedWidth() const { return orderedWidth_; }
 
     /** @brief Return the height of the ordered vertex set */
-    size_t orderedHeight() const { return orderedHeight_; }
+    std::size_t orderedHeight() const { return orderedHeight_; }
     /**@}*/
 
 protected:
@@ -126,9 +128,9 @@ protected:
     /** Is the generated vertex set ordered? */
     bool ordered_{false};
     /** Width of the ordered vertex set */
-    size_t orderedWidth_{0};
+    std::size_t orderedWidth_{0};
     /** Height of the ordered vertex set */
-    size_t orderedHeight_{0};
+    std::size_t orderedHeight_{0};
     /**@}*/
 };
 }  // namespace volcart::shapes

--- a/core/include/vc/core/types/Cache.hpp
+++ b/core/include/vc/core/types/Cache.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 namespace volcart
 {
 /**
@@ -19,13 +21,13 @@ public:
 
     /**@{*/
     /** @brief Set the maximum number of elements in the cache */
-    virtual void setCapacity(size_t newCapacity) = 0;
+    virtual void setCapacity(std::size_t newCapacity) = 0;
 
     /** @brief Get the maximum number of elements in the cache */
-    virtual size_t capacity() const = 0;
+    virtual std::size_t capacity() const = 0;
 
     /** @brief Get the current number of elements in the cache */
-    virtual size_t size() const = 0;
+    virtual std::size_t size() const = 0;
     /**@}*/
 
     /**@{*/
@@ -47,9 +49,9 @@ protected:
     Cache() = default;
 
     /** Constructor with capacity */
-    explicit Cache(size_t capacity) : capacity_{capacity} {}
+    explicit Cache(std::size_t capacity) : capacity_{capacity} {}
 
     /** Maximum number of elements in the cache */
-    size_t capacity_{200};
+    std::size_t capacity_{200};
 };
 }  // namespace volcart

--- a/core/include/vc/core/types/LRUCache.hpp
+++ b/core/include/vc/core/types/LRUCache.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstddef>
 #include <list>
 #include <memory>
 #include <unordered_map>
@@ -59,13 +60,13 @@ public:
     LRUCache() : BaseClass() {}
 
     /** @brief Constructor with cache capacity parameter */
-    explicit LRUCache(size_t capacity) : BaseClass(capacity) {}
+    explicit LRUCache(std::size_t capacity) : BaseClass(capacity) {}
 
     /** @overload LRUCache() */
     static Pointer New() { return std::make_shared<LRUCache<TKey, TValue>>(); }
 
-    /** @overload LRUCache(size_t) */
-    static Pointer New(size_t capacity)
+    /** @overload LRUCache(std::size_t) */
+    static Pointer New(std::size_t capacity)
     {
         return std::make_shared<LRUCache<TKey, TValue>>(capacity);
     }
@@ -73,7 +74,7 @@ public:
 
     /**@{*/
     /** @brief Set the maximum number of elements in the cache */
-    void setCapacity(size_t capacity) override
+    void setCapacity(std::size_t capacity) override
     {
         if (capacity <= 0) {
             throw std::invalid_argument(
@@ -91,10 +92,10 @@ public:
     }
 
     /** @brief Get the maximum number of elements in the cache */
-    size_t capacity() const override { return capacity_; }
+    std::size_t capacity() const override { return capacity_; }
 
     /** @brief Get the current number of elements in the cache */
-    size_t size() const override { return lookup_.size(); }
+    std::size_t size() const override { return lookup_.size(); }
     /**@}*/
 
     /**@{*/

--- a/core/include/vc/core/types/Mixins.hpp
+++ b/core/include/vc/core/types/Mixins.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 #include "vc/core/util/Signals.hpp"
 
 namespace volcart
@@ -11,9 +13,9 @@ namespace volcart
 struct IterationsProgress {
     virtual ~IterationsProgress() = default;
     Signal<> progressStarted;
-    Signal<size_t> progressUpdated;
+    Signal<std::size_t> progressUpdated;
     Signal<> progressComplete;
-    virtual size_t progressIterations() const = 0;
+    virtual std::size_t progressIterations() const = 0;
 };
 
 }  // namespace volcart

--- a/core/include/vc/core/types/NDArray.hpp
+++ b/core/include/vc/core/types/NDArray.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstddef>
 #include <exception>
 #include <functional>
 #include <iostream>
@@ -42,10 +43,10 @@ public:
 
     /**@{*/
     /** @brief Default constructor */
-    explicit NDArray(size_t n) : dim_(n) {}
+    explicit NDArray(std::size_t n) : dim_(n) {}
 
     /** @brief Constructor with dimensions */
-    explicit NDArray(size_t n, Extent e) : dim_(n), extents_(std::move(e))
+    explicit NDArray(std::size_t n, Extent e) : dim_(n), extents_(std::move(e))
     {
         if (extents_.size() != dim_) {
             throw std::invalid_argument("Extents of wrong dimension");
@@ -54,9 +55,9 @@ public:
         resize_container_();
     }
 
-    /** @overload NDArray(size_t n, Extent e) */
+    /** @overload NDArray(std::size_t n, Extent e) */
     template <typename... Es>
-    explicit NDArray(size_t n, Es... extents)
+    explicit NDArray(std::size_t n, Es... extents)
         : dim_(n), extents_{static_cast<IndexType>(extents)...}
     {
         if (sizeof...(extents) != dim_) {
@@ -67,7 +68,7 @@ public:
 
     /** @brief Constructor with range initialization */
     template <typename InputIt>
-    explicit NDArray(size_t n, Extent e, InputIt first, InputIt last)
+    explicit NDArray(std::size_t n, Extent e, InputIt first, InputIt last)
         : dim_(n), extents_(std::move(e)), data_{first, last}
     {
         if (extents_.size() != dim_) {
@@ -109,13 +110,13 @@ public:
     }
 
     /** @brief Get the number of dimensions of the array */
-    size_t dims() const { return dim_; }
+    std::size_t dims() const { return dim_; }
 
     /** @brief Get the extent (size) of the array's dimensions */
     Extent extents() const { return extents_; }
 
     /** @brief Get the total number of elements in the array */
-    size_t size() const { return data_.size(); }
+    std::size_t size() const { return data_.size(); }
     /**@}*/
 
     /**@{*/
@@ -215,7 +216,7 @@ public:
      * @brief Flatten an array by dropping a dimension and appending the
      * data to the next highest dimension
      */
-    static void Flatten(NDArray& a, size_t dim)
+    static void Flatten(NDArray& a, std::size_t dim)
     {
         if (dim == a.dim_) {
             return;
@@ -240,7 +241,7 @@ public:
 
 private:
     /** Number of dimensions */
-    size_t dim_{1};
+    std::size_t dim_{1};
     /** Dimension extents */
     Extent extents_;
     /** Data storage */
@@ -264,7 +265,7 @@ private:
     inline IndexType index_to_data_index_(Index i) const
     {
         IndexType idx{0};
-        for (size_t it = 0; it < extents_.size(); it++) {
+        for (std::size_t it = 0; it < extents_.size(); it++) {
             auto begin = std::next(extents_.begin(), it + 1);
             auto offset = std::accumulate(
                 begin, extents_.end(), IndexType(1),

--- a/core/include/vc/core/types/OrderedPointSet.hpp
+++ b/core/include/vc/core/types/OrderedPointSet.hpp
@@ -3,6 +3,7 @@
 /** @file */
 
 #include <cassert>
+#include <cstddef>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
@@ -52,13 +53,13 @@ public:
     explicit OrderedPointSet() = default;
 
     /** @brief Constructor with width parameter */
-    explicit OrderedPointSet(size_t width) : BaseClass(), width_(width)
+    explicit OrderedPointSet(std::size_t width) : BaseClass(), width_(width)
     {
         data_.reserve(width_ * CAPACITY_MULTIPLIER);
     }
 
     /** @brief Constructor with width parameter and initialization value */
-    explicit OrderedPointSet(size_t width, T initVal)
+    explicit OrderedPointSet(std::size_t width, T initVal)
         : BaseClass(), width_(width)
     {
         data_.assign(width_ * CAPACITY_MULTIPLIER, initVal);
@@ -67,7 +68,7 @@ public:
 
     /**@{*/
     /** @brief Get a point from the OrderedPointSet at row y, column x */
-    const T& operator()(size_t y, size_t x) const
+    const T& operator()(std::size_t y, std::size_t x) const
     {
         assert(x < width_ && "x out of range");
         assert(y * width_ + x < data_.size() && "(x, y) out of range");
@@ -75,7 +76,7 @@ public:
     }
 
     /** @copybrief OrderedPointSet::operator()() */
-    T& operator()(size_t y, size_t x)
+    T& operator()(std::size_t y, std::size_t x)
     {
         assert(x < width_ && "x out of range");
         assert(y * width_ + x < data_.size() && "(x, y) out of range");
@@ -85,12 +86,15 @@ public:
 
     /**@{*/
     /** @brief Return the number of columns in the OrderedPointSet */
-    size_t width() const { return width_; }
+    std::size_t width() const { return width_; }
 
     /** @brief Return the number of rows in the OrderedPointSet */
     // data_.size() should be a perfect multiple of width_, so this should
     // return a whole integer
-    size_t height() const { return (width_ == 0 ? 0 : this->size() / width_); }
+    std::size_t height() const
+    {
+        return (width_ == 0 ? 0 : this->size() / width_);
+    }
 
     /** @brief Set the ordering width
      *
@@ -101,7 +105,7 @@ public:
      * This function throws a std::logic_error if the width has already been
      * set.
      */
-    void setWidth(size_t width)
+    void setWidth(std::size_t width)
     {
         if (width_ != 0) {
             auto msg = "Cannot change width if already set";
@@ -166,7 +170,7 @@ public:
      *
      * Throws a std::range_error if `i` is outside the range of row indices.
      */
-    std::vector<T> getRow(size_t i) const
+    std::vector<T> getRow(std::size_t i) const
     {
         if (i >= this->height()) {
             throw std::range_error("out of range");
@@ -186,7 +190,7 @@ public:
      * Throws a std::range_error if `i` is outside the range of row
      * indices. Throws std::logic_error if `j <= i`.
      */
-    OrderedPointSet copyRows(size_t i, size_t j) const
+    OrderedPointSet copyRows(std::size_t i, std::size_t j) const
     {
         if (i >= this->height() || j > this->height()) {
             throw std::range_error("out of range");
@@ -204,12 +208,13 @@ public:
     /**@{*/
     /** @brief Create an OrderedPointSet of a specific size, filled with an
      * initial value */
-    static OrderedPointSet Fill(size_t width, size_t height, T initVal)
+    static OrderedPointSet Fill(
+        std::size_t width, std::size_t height, T initVal)
     {
         OrderedPointSet ps(width);
         std::vector<T> v;
         v.assign(width, initVal);
-        for (size_t _ = 0; _ < height; ++_) {
+        for (std::size_t _ = 0; _ < height; ++_) {
             ps.pushRow(v);
         }
         return ps;
@@ -218,8 +223,8 @@ public:
 
 private:
     /** Number of columns */
-    size_t width_{0};
+    std::size_t width_{0};
     /** Number of rows preallocated */
-    constexpr static size_t CAPACITY_MULTIPLIER = 20;
+    constexpr static std::size_t CAPACITY_MULTIPLIER = 20;
 };
 }  // namespace volcart

--- a/core/include/vc/core/types/PerPixelMap.hpp
+++ b/core/include/vc/core/types/PerPixelMap.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstddef>
 #include <memory>
 
 #include <opencv2/core.hpp>

--- a/core/include/vc/core/types/PointSet.hpp
+++ b/core/include/vc/core/types/PointSet.hpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -57,10 +58,10 @@ public:
     explicit PointSet() = default;
 
     /** @brief Construct and preallocate a number of Point elements */
-    explicit PointSet(size_t initSize) { data_.reserve(initSize); }
+    explicit PointSet(std::size_t initSize) { data_.reserve(initSize); }
 
     /** @brief Construct and fill a number of elements with an initial value */
-    explicit PointSet(size_t initSize, T initVal)
+    explicit PointSet(std::size_t initSize, T initVal)
     {
         data_.assign(initSize, initVal);
     }
@@ -68,14 +69,14 @@ public:
 
     /**@{*/
     /** @brief Get a Point by index */
-    const T& operator[](size_t idx) const
+    const T& operator[](std::size_t idx) const
     {
         assert(idx < data_.size() && "idx out of range");
         return data_[idx];
     }
 
     /** @copydoc operator[]() */
-    T& operator[](size_t idx)
+    T& operator[](std::size_t idx)
     {
         assert(idx < data_.size() && "idx out of range");
         return data_[idx];
@@ -84,7 +85,7 @@ public:
 
     /**@{*/
     /** @brief Get the size of the PointSet */
-    size_t size() const { return data_.size(); }
+    std::size_t size() const { return data_.size(); }
 
     /** @brief Return whether the PointSet is empty */
     bool empty() const { return data_.empty(); }
@@ -195,7 +196,7 @@ public:
     /**@{*/
     /** @brief Create a PointSet of a specific size, filled with an initial
      * value */
-    static PointSet Fill(size_t initSize, T initVal)
+    static PointSet Fill(std::size_t initSize, T initVal)
     {
         return PointSet(initSize, initVal);
     }

--- a/core/include/vc/core/types/SimpleMesh.hpp
+++ b/core/include/vc/core/types/SimpleMesh.hpp
@@ -10,6 +10,7 @@
  * @ingroup Types
  */
 
+#include <cstdint>
 #include <iostream>
 
 namespace volcart
@@ -24,9 +25,12 @@ struct SimpleMesh {
 
     /** Generic triangular face structure */
     struct Cell {
-        uint64_t v1, v2, v3;
+        std::uint64_t v1, v2, v3;
         Cell() = default;
-        Cell(uint64_t p1, uint64_t p2, uint64_t p3) : v1{p1}, v2{p2}, v3{p3} {}
+        Cell(std::uint64_t p1, std::uint64_t p2, std::uint64_t p3)
+            : v1{p1}, v2{p2}, v3{p3}
+        {
+        }
     };
 
     std::vector<Vertex> verts;

--- a/core/include/vc/core/types/Transforms.hpp
+++ b/core/include/vc/core/types/Transforms.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstddef>
 #include <iostream>
 #include <memory>
 #include <string>

--- a/core/include/vc/core/types/UVMap.hpp
+++ b/core/include/vc/core/types/UVMap.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstddef>
 #include <map>
 #include <memory>
 
@@ -37,7 +38,7 @@ const static cv::Vec2d NULL_MAPPING{-1, -1};
  * different origin positions. By setting the origin prior to insertion and
  * again prior to retrieval, mappings can be inserted relative to one origin but
  * retrieved relative to another. When using the overloaded
- * set(size_t, const cv::Vec2d&) and get(size_t) functions, the source and
+ * set(std::size_t, const cv::Vec2d&) and get(size_t) functions, the source and
  * target origins are set using the constructor or setOrigin().
  *
  * Since UV maps store \em relative position information, they are agnostic to
@@ -78,7 +79,7 @@ public:
 
     /**@{*/
     /** @brief Return the number of UV elements */
-    [[nodiscard]] auto size() const -> size_t;
+    [[nodiscard]] auto size() const -> std::size_t;
 
     /** @brief Return whether the UVMap is empty */
     [[nodiscard]] auto empty() const -> bool;
@@ -102,34 +103,34 @@ public:
      *
      * Point is inserted relative to the provided origin.
      */
-    void set(size_t id, const cv::Vec2d& uv, const Origin& o);
+    void set(std::size_t id, const cv::Vec2d& uv, const Origin& o);
 
     /**
      * @copybrief set()
      *
      * Point is inserted relative to the origin returned by origin().
      */
-    void set(size_t id, const cv::Vec2d& uv);
+    void set(std::size_t id, const cv::Vec2d& uv);
 
     /**
      * @brief Get the UV value for a point by ID
      *
      * Point is retrieved relative to the provided origin.
      */
-    [[nodiscard]] auto get(size_t id, const Origin& o) const -> cv::Vec2d;
+    [[nodiscard]] auto get(std::size_t id, const Origin& o) const -> cv::Vec2d;
 
     /**
      * @copybrief get()
      *
      * Point is retrieved relative to the origin returned by origin().
      */
-    [[nodiscard]] auto get(size_t id) const -> cv::Vec2d;
+    [[nodiscard]] auto get(std::size_t id) const -> cv::Vec2d;
 
     /** @brief Check if the vertex index has a UV mapping */
     [[nodiscard]] auto contains(std::size_t id) const -> bool;
 
     /** Access to underlying data. For serialization only. */
-    [[nodiscard]] auto as_map() const -> std::map<size_t, cv::Vec2d>;
+    [[nodiscard]] auto as_map() const -> std::map<std::size_t, cv::Vec2d>;
     /**@}*/
 
     /**@{*/
@@ -234,7 +235,7 @@ public:
 
 private:
     /** UV storage */
-    std::map<size_t, cv::Vec2d> map_;
+    std::map<std::size_t, cv::Vec2d> map_;
     /** Origin for set and get functions */
     Origin origin_{Origin::TopLeft};
     /** Aspect ratio */

--- a/core/include/vc/core/types/Volume.hpp
+++ b/core/include/vc/core/types/Volume.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+#include <cstdint>
 #include <mutex>
 
 #include "vc/core/filesystem.hpp"
@@ -43,7 +45,7 @@ public:
     using DefaultCache = LRUCache<int, cv::Mat>;
 
     /** Default slice cache capacity */
-    static constexpr size_t DEFAULT_CAPACITY = 200;
+    static constexpr std::size_t DEFAULT_CAPACITY = 200;
 
     /**@{*/
     /** Default constructor. Cannot be constructed without path. */
@@ -84,7 +86,7 @@ public:
     /** @brief Set the expected height of the slice images */
     void setSliceHeight(int h);
     /** @brief Set the expected number of slice images */
-    void setNumberOfSlices(size_t numSlices);
+    void setNumberOfSlices(std::size_t numSlices);
     /** @brief Set the voxel size (in microns) */
     void setVoxelSize(double s);
     /** @brief Set the minimum value in the Volume */
@@ -130,10 +132,10 @@ public:
 
     /**@{*/
     /** @brief Get the intensity value at a voxel position */
-    uint16_t intensityAt(int x, int y, int z) const;
+    std::uint16_t intensityAt(int x, int y, int z) const;
 
     /** @copydoc intensityAt() */
-    uint16_t intensityAt(const cv::Vec3d& v) const
+    std::uint16_t intensityAt(const cv::Vec3d& v) const
     {
         return intensityAt(int(v[0]), int(v[1]), int(v[2]));
     }
@@ -146,10 +148,10 @@ public:
      * Trilinear interpolation equation from
      * <a href = "http://paulbourke.net/miscellaneous/interpolation/"> here</a>.
      */
-    uint16_t interpolateAt(double x, double y, double z) const;
+    std::uint16_t interpolateAt(double x, double y, double z) const;
 
     /** @copydoc interpolateAt(double, double, double) const */
-    uint16_t interpolateAt(const cv::Vec3d& v) const
+    std::uint16_t interpolateAt(const cv::Vec3d& v) const
     {
         return interpolateAt(v[0], v[1], v[2]);
     }
@@ -183,23 +185,23 @@ public:
     void setCache(SliceCache::Pointer c) { cache_ = std::move(c); }
 
     /** @brief Set the maximum number of cached slices */
-    void setCacheCapacity(size_t newCacheCapacity)
+    void setCacheCapacity(std::size_t newCacheCapacity)
     {
         cache_->setCapacity(newCacheCapacity);
     }
 
     /** @brief Set the maximum size of the cache in bytes */
-    void setCacheMemoryInBytes(size_t nbytes)
+    void setCacheMemoryInBytes(std::size_t nbytes)
     {
         // x2 because pixels are 16 bits normally. Not a great solution.
         setCacheCapacity(nbytes / (sliceWidth() * sliceHeight() * 2));
     }
 
     /** @brief Get the maximum number of cached slices */
-    size_t getCacheCapacity() const { return cache_->capacity(); }
+    std::size_t getCacheCapacity() const { return cache_->capacity(); }
 
     /** @brief Get the current number of cached slices */
-    size_t getCacheSize() const { return cache_->size(); }
+    std::size_t getCacheSize() const { return cache_->size(); }
 
     /** @brief Purge the slice cache */
     void cachePurge() { cache_->purge(); }

--- a/core/include/vc/core/types/VolumeMask.hpp
+++ b/core/include/vc/core/types/VolumeMask.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstddef>
 #include <vector>
 
 #include <Eigen/SparseCore>
@@ -32,7 +33,7 @@ public:
     using Subvolume = NDArray<State>;
 
     /** @brief Construct from Volume dimensions */
-    VolumeMask(size_t width, size_t height, size_t numSlices);
+    VolumeMask(std::size_t width, std::size_t height, std::size_t numSlices);
 
     /** @brief Set the segmentation state for a voxel */
     void setVoxelState(const cv::Vec3i& xyz, State state);
@@ -67,10 +68,10 @@ private:
     Eigen::SparseMatrix<int, Eigen::RowMajor> states_;
 
     /** Slice width */
-    size_t sliceWidth_;
+    std::size_t sliceWidth_;
 
     /** Slice height */
-    size_t sliceHeight_;
+    std::size_t sliceHeight_;
 };
 
 }  // namespace volcart

--- a/core/include/vc/core/util/ApplyLUT.hpp
+++ b/core/include/vc/core/util/ApplyLUT.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 #include <opencv2/core.hpp>
 
 namespace volcart

--- a/core/include/vc/core/util/Canny.hpp
+++ b/core/include/vc/core/util/Canny.hpp
@@ -4,6 +4,7 @@
 
 /** @file */
 
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/core/include/vc/core/util/ColorMaps.hpp
+++ b/core/include/vc/core/util/ColorMaps.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 #include <opencv2/core.hpp>
 
 namespace volcart

--- a/core/include/vc/core/util/DateTime.hpp
+++ b/core/include/vc/core/util/DateTime.hpp
@@ -7,6 +7,7 @@
  */
 
 #include <chrono>
+#include <cstddef>
 #include <ctime>
 #include <iomanip>
 #include <iostream>

--- a/core/include/vc/core/util/HashFunctions.hpp
+++ b/core/include/vc/core/util/HashFunctions.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 #include <opencv2/core.hpp>
 
 namespace volcart
@@ -16,10 +18,10 @@ namespace volcart
  */
 template <class Vector>
 struct Vec3Hash {
-    size_t operator()(const Vector& v) const
+    std::size_t operator()(const Vector& v) const
     {
         auto max = std::max({v[0], v[1], v[2]});
-        size_t hash = (max * max * max) + (2 * max * v[2]) + v[2];
+        std::size_t hash = (max * max * max) + (2 * max * v[2]) + v[2];
         if (max == v[2]) {
             auto val = std::max({v[0], v[1]});
             hash += val * val;

--- a/core/include/vc/core/util/Iteration.hpp
+++ b/core/include/vc/core/util/Iteration.hpp
@@ -3,6 +3,7 @@
 /** @file */
 
 #include <cmath>
+#include <cstddef>
 #include <iostream>
 #include <type_traits>
 
@@ -36,7 +37,7 @@ private:
 
     public:
         /** @{ Iterator type traits */
-        using difference_type = size_t;
+        using difference_type = std::size_t;
         using value_type = ItT;
         using pointer = value_type*;
         using reference = value_type const&;
@@ -104,16 +105,16 @@ public:
 
     /** Returns the size of the range (floating point ranges) */
     template <typename Q = T>
-    std::enable_if_t<std::is_floating_point<Q>::value, size_t> size() const
+    std::enable_if_t<std::is_floating_point<Q>::value, std::size_t> size() const
     {
-        return static_cast<size_t>(std::ceil((end_ - start_) / step_));
+        return static_cast<std::size_t>(std::ceil((end_ - start_) / step_));
     }
 
     /** Returns the size of the range (integral ranges) */
     template <typename Q = T>
-    std::enable_if_t<std::is_integral<Q>::value, size_t> size() const
+    std::enable_if_t<std::is_integral<Q>::value, std::size_t> size() const
     {
-        return static_cast<size_t>((end_ - start_) / step_);
+        return static_cast<std::size_t>((end_ - start_) / step_);
     }
 
 private:
@@ -212,7 +213,7 @@ private:
 
     public:
         /** @{ Iterator type traits */
-        using difference_type = size_t;
+        using difference_type = std::size_t;
         using value_type = std::pair<ItT const&, ItT const&>;
         using pointer = value_type*;
         using reference = value_type;
@@ -298,18 +299,20 @@ public:
 
     /** Returns the size of the range (floating point ranges) */
     template <typename Q = T>
-    std::enable_if_t<std::is_floating_point<Q>::value, size_t> size() const
+    std::enable_if_t<std::is_floating_point<Q>::value, std::size_t> size() const
     {
-        auto vLen = static_cast<size_t>(std::ceil((vEnd_ - vStart_) / step_));
-        return static_cast<size_t>(std::ceil((uEnd_ - uStart_) / step_)) * vLen;
+        auto vLen =
+            static_cast<std::size_t>(std::ceil((vEnd_ - vStart_) / step_));
+        return static_cast<std::size_t>(std::ceil((uEnd_ - uStart_) / step_)) *
+               vLen;
     }
 
     /** Returns the size of the range (integral ranges) */
     template <typename Q = T>
-    std::enable_if_t<std::is_integral<Q>::value, size_t> size() const
+    std::enable_if_t<std::is_integral<Q>::value, std::size_t> size() const
     {
-        auto vLen = static_cast<size_t>((vEnd_ - vStart_) / step_);
-        return static_cast<size_t>((uEnd_ - uStart_) / step_) * vLen;
+        auto vLen = static_cast<std::size_t>((vEnd_ - vStart_) / step_);
+        return static_cast<std::size_t>((uEnd_ - uStart_) / step_) * vLen;
     }
 
 private:
@@ -403,20 +406,21 @@ private:
     class EnumerateIterator
     {
     private:
-        size_t idx_;
+        std::size_t idx_;
         T it_;
 
     public:
         /** @{ Iterator type traits */
-        using difference_type = size_t;
-        using value_type = std::pair<size_t, decltype(*std::declval<T&>())&>;
+        using difference_type = std::size_t;
+        using value_type =
+            std::pair<std::size_t, decltype(*std::declval<T&>())&>;
         using pointer = value_type*;
         using reference = value_type;
         using iterator_category = std::input_iterator_tag;
         /** @} */
 
         /** Constructor for the iterator */
-        explicit EnumerateIterator(size_t idx, T&& it)
+        explicit EnumerateIterator(std::size_t idx, T&& it)
             : idx_{idx}, it_{std::move(it)}
         {
         }

--- a/core/include/vc/core/util/LinearNeighborhoodSize.hpp
+++ b/core/include/vc/core/util/LinearNeighborhoodSize.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 #include "vc/core/neighborhood/NeighborhoodGenerator.hpp"
 #include "vc/core/types/Volume.hpp"
 
@@ -13,7 +15,7 @@ namespace volcart
  *
  * @ingroup Util
  */
-static size_t LinearNeighborhoodSize(
+static std::size_t LinearNeighborhoodSize(
     double radius, double interval, Direction dir)
 {
     // Setup Range
@@ -37,6 +39,6 @@ static size_t LinearNeighborhoodSize(
         }
     }
 
-    return static_cast<size_t>(std::floor((max - min) / interval) + 1);
+    return static_cast<std::size_t>(std::floor((max - min) / interval) + 1);
 }
 }  // namespace volcart

--- a/core/include/vc/core/util/MemorySizeStringParser.hpp
+++ b/core/include/vc/core/util/MemorySizeStringParser.hpp
@@ -8,6 +8,7 @@
  * @ingroup Util
  */
 
+#include <cstddef>
 #include <string>
 
 namespace volcart
@@ -27,10 +28,10 @@ enum class MemoryStringFormat { Int, Float };
  * Input: "1K", Output: 1024
  * Input: "1M", Output: 1048576
  */
-size_t MemorySizeStringParser(const std::string& s);
+std::size_t MemorySizeStringParser(const std::string& s);
 
 std::string BytesToMemorySizeString(
-    size_t bytes,
+    std::size_t bytes,
     const std::string& suffix = "GB",
     MemoryStringFormat fmt = MemoryStringFormat::Int);
 }  // namespace volcart

--- a/core/include/vc/core/util/Signals.hpp
+++ b/core/include/vc/core/util/Signals.hpp
@@ -97,7 +97,7 @@ public:
     void disconnect() { connections_.clear(); }
 
     /** @brief Get the number of connected slots */
-    size_t numConnections() const { return connections_.size(); }
+    std::size_t numConnections() const { return connections_.size(); }
 
     /** @brief Signal all connections with parameters */
     void send(Types... args) const

--- a/core/include/vc/core/util/String.hpp
+++ b/core/include/vc/core/util/String.hpp
@@ -203,7 +203,7 @@ static inline std::vector<std::string> split(
     // Split string
     std::vector<std::string> tokens;
     std::string::size_type begin{0};
-    for (size_t it = 0; it < delimPos.size(); it++) {
+    for (std::size_t it = 0; it < delimPos.size(); it++) {
         auto end = delimPos[it];
         auto t = s.substr(begin, end - begin);
         if (not t.empty()) {

--- a/core/python/PyPerPixelMap.cpp
+++ b/core/python/PyPerPixelMap.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <tuple>
 
 #include <pybind11/pybind11.h>
@@ -25,12 +26,14 @@ void init_PerPixelMap(py::module& m)
     /** Element Access */
     c.def(
         "__getitem__",
-        [](vc::PerPixelMap& p, std::tuple<size_t, size_t> pos) {
+        [](vc::PerPixelMap& p, std::tuple<std::size_t, std::size_t> pos) {
             return p(std::get<0>(pos), std::get<1>(pos));
         },
         py::arg("pos[y, x]"), "Get the mapping for a pixel by coordinate");
     c.def(
-        "get", py::overload_cast<size_t, size_t>(&vc::PerPixelMap::operator()),
+        "get",
+        py::overload_cast<std::size_t, std::size_t>(
+            &vc::PerPixelMap::operator()),
         py::arg("y"), py::arg("x"),
         "Get the mapping for a pixel by coordinate");
     c.def(

--- a/core/python/PyVolume.cpp
+++ b/core/python/PyVolume.cpp
@@ -1,3 +1,6 @@
+#include <cstddef>
+#include <cstdint>
+
 #include <pybind11/pybind11.h>
 
 #include "vc/core/neighborhood/CuboidGenerator.hpp"
@@ -89,10 +92,10 @@ void init_Volume(py::module& m)
             auto s = subvolume.compute(
                 v.shared_from_this(), center, {xvec, yvec, zvec});
             auto buf = s.as_vector();
-            size_t size = sizeof(uint16_t);
-            std::string format = py::format_descriptor<uint16_t>::format();
+            std::size_t size = sizeof(std::uint16_t);
+            std::string format = py::format_descriptor<std::uint16_t>::format();
             auto extents = s.extents();
-            std::vector<size_t> strides{
+            std::vector<std::size_t> strides{
                 size * extents[1] * extents[0], size * extents[0], size};
             return py::array(py::buffer_info{
                                  buf.data(), static_cast<ssize_t>(size), format,

--- a/core/src/ApplyLUT.cpp
+++ b/core/src/ApplyLUT.cpp
@@ -1,5 +1,7 @@
 #include "vc/core/util/ApplyLUT.hpp"
 
+#include <cstdint>
+
 #include <opencv2/imgproc.hpp>
 
 #include "vc/core/util/ImageConversion.hpp"
@@ -69,7 +71,7 @@ cv::Mat vc::ApplyLUT(
 
         // Assign to image
         if (lut.channels() == 1) {
-            output.at<uint8_t>(y, x) = lut.at<uint8_t>(0, bin);
+            output.at<std::uint8_t>(y, x) = lut.at<std::uint8_t>(0, bin);
         } else if (lut.channels() == 3) {
             output.at<cv::Vec3b>(y, x) = lut.at<cv::Vec3b>(0, bin);
         }
@@ -131,7 +133,7 @@ cv::Mat vc::ApplyLUT(
 
         // Assign to image
         if (lut.channels() == 1) {
-            output.at<uint8_t>(y, x) = lut.at<uint8_t>(0, bin);
+            output.at<std::uint8_t>(y, x) = lut.at<std::uint8_t>(0, bin);
         } else if (lut.channels() == 3) {
             output.at<cv::Vec3b>(y, x) = lut.at<cv::Vec3b>(0, bin);
         }
@@ -156,7 +158,7 @@ cv::Mat vc::ApplyLUT(
 }
 
 cv::Mat vc::GenerateLUTScaleBar(
-    const cv::Mat& lut, bool invert, size_t height, size_t width)
+    const cv::Mat& lut, bool invert, std::size_t height, std::size_t width)
 {
     // Construct a single row
     auto maxDim = static_cast<int>(std::max(width, height));

--- a/core/src/ColorMaps.cpp
+++ b/core/src/ColorMaps.cpp
@@ -1,6 +1,7 @@
 #include "vc/core/util/ColorMaps.hpp"
 
 #include <array>
+#include <cstdint>
 #include <limits>
 #include <unordered_map>
 
@@ -57,7 +58,7 @@ cv::Mat vc::GetColorMapLUT(ColorMap cm, std::size_t bins)
     }
 
     // Convert to 8bpc
-    lut.convertTo(lut, CV_8U, std::numeric_limits<uint8_t>::max());
+    lut.convertTo(lut, CV_8U, std::numeric_limits<std::uint8_t>::max());
     return lut;
 }
 

--- a/core/src/CuboidGenerator.cpp
+++ b/core/src/CuboidGenerator.cpp
@@ -1,5 +1,6 @@
 #include "vc/core/neighborhood/CuboidGenerator.hpp"
 
+#include <cstddef>
 #include <exception>
 
 static const std::vector<cv::Vec3d> BASIS_VECTORS = {
@@ -56,9 +57,9 @@ Neighborhood CuboidGenerator::compute(
 
     // Iterate over the axes
     Neighborhood output(3, extent);
-    for (size_t z = 0; z < extent[0]; ++z) {
-        for (size_t y = 0; y < extent[1]; ++y) {
-            for (size_t x = 0; x < extent[2]; ++x) {
+    for (std::size_t z = 0; z < extent[0]; ++z) {
+        for (std::size_t y = 0; y < extent[1]; ++y) {
+            for (std::size_t x = 0; x < extent[2]; ++x) {
 
                 // Offset along each axis
                 auto zOffset = -radius[0] + (z * interval_);
@@ -85,11 +86,11 @@ Neighborhood::Extent CuboidGenerator::extents() const
 
     Neighborhood::Extent extent;
     extent.emplace_back(
-        static_cast<size_t>(std::floor(2.0 * radius / interval_) + 1));
+        static_cast<std::size_t>(std::floor(2.0 * radius / interval_) + 1));
     extent.emplace_back(
-        static_cast<size_t>(std::floor(2.0 * radius_[1] / interval_) + 1));
+        static_cast<std::size_t>(std::floor(2.0 * radius_[1] / interval_) + 1));
     extent.emplace_back(
-        static_cast<size_t>(std::floor(2.0 * radius_[2] / interval_) + 1));
+        static_cast<std::size_t>(std::floor(2.0 * radius_[2] / interval_) + 1));
 
     return extent;
 }

--- a/core/src/ITKMesh.cpp
+++ b/core/src/ITKMesh.cpp
@@ -1,5 +1,7 @@
 #include "vc/core/types/ITKMesh.hpp"
 
+#include <cstdint>
+
 using namespace volcart;
 namespace vc = volcart;
 
@@ -30,7 +32,7 @@ void vc::DeepCopy(
              cell != input->GetCells()->End(); ++cell) {
 
             c.TakeOwnership(new ITKTriangle);
-            for (uint32_t pointId = 0;
+            for (std::uint32_t pointId = 0;
                  pointId < cell.Value()->GetNumberOfPoints(); ++pointId) {
                 c->SetPointId(
                     pointId, cell.Value()->GetPointIdsContainer()[pointId]);

--- a/core/src/ImageConversion.cpp
+++ b/core/src/ImageConversion.cpp
@@ -1,24 +1,27 @@
 #include "vc/core/util/ImageConversion.hpp"
 
+#include <cstdint>
+
 namespace vc = volcart;
 
-static inline auto CreateAlphaChannel(const cv::Size& size, int depth)
-    -> cv::Mat
+namespace
+{
+auto CreateAlphaChannel(const cv::Size& size, int depth) -> cv::Mat
 {
     // Create and scale the alpha channel
     cv::Mat alpha = cv::Mat::ones(size, depth);
     switch (alpha.depth()) {
         case CV_8U:
-            alpha *= std::numeric_limits<uint8_t>::max();
+            alpha *= std::numeric_limits<std::uint8_t>::max();
             break;
         case CV_8S:
-            alpha *= std::numeric_limits<int8_t>::max();
+            alpha *= std::numeric_limits<std::int8_t>::max();
             break;
         case CV_16U:
-            alpha *= std::numeric_limits<uint16_t>::max();
+            alpha *= std::numeric_limits<std::uint16_t>::max();
             break;
         case CV_16S:
-            alpha *= std::numeric_limits<int16_t>::max();
+            alpha *= std::numeric_limits<std::int16_t>::max();
             break;
         default:
             // do nothing
@@ -27,6 +30,7 @@ static inline auto CreateAlphaChannel(const cv::Size& size, int depth)
 
     return alpha;
 }
+}  // namespace
 
 auto vc::DepthToString(int depth) -> std::string
 {
@@ -63,16 +67,16 @@ auto vc::QuantizeImage(const cv::Mat& m, int depth, bool scaleMinMax) -> cv::Mat
     double outputMax{1.0};
     switch (depth) {
         case CV_8U:
-            outputMax = std::numeric_limits<uint8_t>::max();
+            outputMax = std::numeric_limits<std::uint8_t>::max();
             break;
         case CV_8S:
-            outputMax = std::numeric_limits<int8_t>::max();
+            outputMax = std::numeric_limits<std::int8_t>::max();
             break;
         case CV_16U:
-            outputMax = std::numeric_limits<uint16_t>::max();
+            outputMax = std::numeric_limits<std::uint16_t>::max();
             break;
         case CV_16S:
-            outputMax = std::numeric_limits<int16_t>::max();
+            outputMax = std::numeric_limits<std::int16_t>::max();
             break;
         default:
             // do nothing
@@ -87,16 +91,16 @@ auto vc::QuantizeImage(const cv::Mat& m, int depth, bool scaleMinMax) -> cv::Mat
     } else {
         switch (m.depth()) {
             case CV_8U:
-                max = std::numeric_limits<uint8_t>::max();
+                max = std::numeric_limits<std::uint8_t>::max();
                 break;
             case CV_8S:
-                max = std::numeric_limits<int8_t>::max();
+                max = std::numeric_limits<std::int8_t>::max();
                 break;
             case CV_16U:
-                max = std::numeric_limits<uint16_t>::max();
+                max = std::numeric_limits<std::uint16_t>::max();
                 break;
             case CV_16S:
-                max = std::numeric_limits<int16_t>::max();
+                max = std::numeric_limits<std::int16_t>::max();
                 break;
             default:
                 // do nothing

--- a/core/src/LineGenerator.cpp
+++ b/core/src/LineGenerator.cpp
@@ -1,5 +1,7 @@
 #include "vc/core/neighborhood/LineGenerator.hpp"
 
+#include <cstddef>
+
 #include "vc/core/util/FloatComparison.hpp"
 
 using namespace volcart;
@@ -45,9 +47,10 @@ Neighborhood LineGenerator::compute(
     }
 
     // Iterate through range
-    auto count = static_cast<size_t>(std::floor((max - min) / interval_) + 1);
+    auto count =
+        static_cast<std::size_t>(std::floor((max - min) / interval_) + 1);
     Neighborhood n(1, count);
-    for (size_t it = 0; it < count; it++) {
+    for (std::size_t it = 0; it < count; it++) {
         auto offset = min + (it * interval_);
         n(it) = v->interpolateAt(pt + (axes[0] * offset));
     }
@@ -59,5 +62,5 @@ Neighborhood::Extent LineGenerator::extents() const
 {
     auto radius =
         (direction_ != Direction::Bidirectional) ? radius_[0] / 2 : radius_[0];
-    return {static_cast<size_t>(std::floor(2.0 * radius / interval_) + 1)};
+    return {static_cast<std::size_t>(std::floor(2.0 * radius / interval_) + 1)};
 }

--- a/core/src/MemorySizeStringParser.cpp
+++ b/core/src/MemorySizeStringParser.cpp
@@ -4,14 +4,14 @@
 #include <regex>
 #include <sstream>
 
-static constexpr size_t BYTES_PER_KB = 1024;
-static constexpr size_t BYTES_PER_MB = BYTES_PER_KB * 1024;
-static constexpr size_t BYTES_PER_GB = BYTES_PER_MB * 1024;
-static constexpr size_t BYTES_PER_TB = BYTES_PER_GB * 1024;
+static constexpr std::size_t BYTES_PER_KB = 1024;
+static constexpr std::size_t BYTES_PER_MB = BYTES_PER_KB * 1024;
+static constexpr std::size_t BYTES_PER_GB = BYTES_PER_MB * 1024;
+static constexpr std::size_t BYTES_PER_TB = BYTES_PER_GB * 1024;
 
 std::string to_string(const float val, const int n = 5);
 
-size_t volcart::MemorySizeStringParser(const std::string& s)
+std::size_t volcart::MemorySizeStringParser(const std::string& s)
 {
     // Regex patterns. Stored as string for easy concatenation.
     std::string numRE{"^[0-9]+"};
@@ -25,7 +25,7 @@ size_t volcart::MemorySizeStringParser(const std::string& s)
     // Match the integer value
     std::smatch match;
     std::regex_search(s, match, std::regex{numRE});
-    size_t value = std::stoull(match[0]);
+    std::size_t value = std::stoull(match[0]);
 
     // Match the suffix
     std::regex_search(s, match, std::regex{multRE, std::regex::icase});
@@ -59,7 +59,7 @@ size_t volcart::MemorySizeStringParser(const std::string& s)
 }
 
 std::string volcart::BytesToMemorySizeString(
-    size_t bytes, const std::string& suffix, MemoryStringFormat fmt)
+    std::size_t bytes, const std::string& suffix, MemoryStringFormat fmt)
 {
     // Return value / multiplier
     // TB

--- a/core/src/OBJReader.cpp
+++ b/core/src/OBJReader.cpp
@@ -1,5 +1,6 @@
 #include "vc/core/io/OBJReader.hpp"
 
+#include <cstddef>
 #include <regex>
 #include <string>
 
@@ -15,7 +16,7 @@ namespace fs = volcart::filesystem;
 
 // Constant for validating face values
 constexpr static int NOT_PRESENT = -1;
-constexpr static size_t VALID_FACE_SIZE = 3;
+constexpr static std::size_t VALID_FACE_SIZE = 3;
 
 void OBJReader::setPath(const filesystem::path& p) { path_ = p; }
 

--- a/core/src/OBJWriter.cpp
+++ b/core/src/OBJWriter.cpp
@@ -1,5 +1,6 @@
 #include "vc/core/io/OBJWriter.hpp"
 
+#include <cstdint>
 #include <string>
 
 #include "vc/core/io/ImageIO.hpp"
@@ -158,8 +159,8 @@ auto OBJWriter::write_vertices_() -> int
     outputMesh_ << "# Vertices: " << mesh_->GetNumberOfPoints() << "\n";
 
     // Iterate over all of the points
-    uint32_t vIndex = 1;
-    uint32_t vnIndex = 1;
+    std::uint32_t vIndex = 1;
+    std::uint32_t vnIndex = 1;
     for (auto pt = mesh_->GetPoints()->Begin(); pt != mesh_->GetPoints()->End();
          pt++) {
         // Make a new point link for this point
@@ -206,8 +207,8 @@ auto OBJWriter::write_texture_coordinates_() -> int
     outputMesh_ << "usemtl default\n";
 
     // Iterate over all of the saved coordinates in our coordinate map
-    uint32_t vtIndex = 1;
-    for (uint32_t pId = 0; pId < uvMap_->size(); ++pId) {
+    std::uint32_t vtIndex = 1;
+    for (std::uint32_t pId = 0; pId < uvMap_->size(); ++pId) {
         cv::Vec2d uv = uvMap_->get(pId);
         outputMesh_ << "vt " << uv[0] << " " << uv[1] << "\n";
 

--- a/core/src/PLYReader.cpp
+++ b/core/src/PLYReader.cpp
@@ -1,5 +1,7 @@
 #include "vc/core/io/PLYReader.hpp"
 
+#include <cstdint>
+
 #include "vc/core/types/Exceptions.hpp"
 #include "vc/core/util/Logging.hpp"
 #include "vc/core/util/String.hpp"
@@ -153,7 +155,7 @@ void PLYReader::read_faces_()
 void PLYReader::create_mesh_()
 {
     ITKPoint p;
-    uint32_t pointCount = 0;
+    std::uint32_t pointCount = 0;
     for (auto& cur : pointList_) {
         p[0] = cur.x;
         p[1] = cur.y;
@@ -168,7 +170,7 @@ void PLYReader::create_mesh_()
         }
         pointCount++;
     }
-    uint32_t faceCount = 0;
+    std::uint32_t faceCount = 0;
     for (auto& cur : faceList_) {
         ITKCell::CellAutoPointer cellpointer;
         cellpointer.TakeOwnership(new ITKTriangle);

--- a/core/src/PLYWriter.cpp
+++ b/core/src/PLYWriter.cpp
@@ -1,5 +1,7 @@
 #include "vc/core/io/PLYWriter.hpp"
 
+#include <cstddef>
+
 #include "vc/core/types/Exceptions.hpp"
 #include "vc/core/util/Logging.hpp"
 
@@ -7,15 +9,18 @@ using namespace volcart;
 using namespace volcart::io;
 namespace fs = volcart::filesystem;
 
-static inline auto PtIntensity(
+namespace
+{
+auto PtIntensity(
     std::size_t idx, const UVMap::Pointer& uvMap, const cv::Mat& image)
     -> double
 {
     auto uv = uvMap->get(idx);
     int u = cvRound(uv[0] * (image.cols - 1));
     int v = cvRound(uv[1] * (image.rows - 1));
-    return image.at<uint16_t>(v, u);
+    return image.at<std::uint16_t>(v, u);
 }
+}  // namespace
 
 ///// Output Methods /////
 auto PLYWriter::write() -> int
@@ -162,7 +167,7 @@ auto PLYWriter::write_faces_() -> int
     return EXIT_SUCCESS;
 }
 
-void PLYWriter::setVertexColors(const std::vector<uint16_t>& c)
+void PLYWriter::setVertexColors(const std::vector<std::uint16_t>& c)
 {
     vcolors_ = c;
 }

--- a/core/src/PerPixelMap.cpp
+++ b/core/src/PerPixelMap.cpp
@@ -180,7 +180,7 @@ auto PerPixelMap::hasMapping(std::size_t y, std::size_t x) const -> bool
         return true;
     }
 
-    return mask_.at<uint8_t>(y, x) == 255;
+    return mask_.at<std::uint8_t>(y, x) == 255;
 }
 auto PerPixelMap::width() const -> std::size_t { return width_; }
 auto PerPixelMap::height() const -> std::size_t { return height_; }

--- a/core/src/ShapePrimitive.cpp
+++ b/core/src/ShapePrimitive.cpp
@@ -19,7 +19,7 @@ ITKMesh::Pointer ShapePrimitive::itkMesh()
     // points + normals
     ITKPoint point;
     ITKPixel normal;
-    for (size_t pId = 0; pId < points_.size(); ++pId) {
+    for (std::size_t pId = 0; pId < points_.size(); ++pId) {
         point[0] = points_[pId].x;
         point[1] = points_[pId].y;
         point[2] = points_[pId].z;
@@ -33,7 +33,7 @@ ITKMesh::Pointer ShapePrimitive::itkMesh()
 
     // cells
     ITKCell::CellAutoPointer cell;
-    for (size_t cId = 0; cId < cells_.size(); ++cId) {
+    for (std::size_t cId = 0; cId < cells_.size(); ++cId) {
         cell.TakeOwnership(new ITKTriangle);
         cell->SetPointId(0, cells_[cId].v1);
         cell->SetPointId(1, cells_[cId].v2);
@@ -58,7 +58,7 @@ vtkSmartPointer<vtkPolyData> ShapePrimitive::vtkMesh()
     pointNormals->SetNumberOfComponents(3);
     pointNormals->SetNumberOfTuples(points_.size());
 
-    for (size_t pId = 0; pId < points_.size(); ++pId) {
+    for (std::size_t pId = 0; pId < points_.size(); ++pId) {
 
         // put normals for the current point in an array
         std::array<double, 3> ptNorm = {
@@ -146,7 +146,7 @@ volcart::OrderedPointSet<cv::Vec6d> ShapePrimitive::orderedPointNormal()
     volcart::OrderedPointSet<cv::Vec6d> output{orderedWidth_};
     std::vector<cv::Vec6d> tempRow;
     for (auto p : points_) {
-        for (size_t i = 0; i < orderedWidth_; i++) {
+        for (std::size_t i = 0; i < orderedWidth_; i++) {
             tempRow.emplace_back(p.x, p.y, p.z, p.nx, p.ny, p.nz);
         }
         output.pushRow(tempRow);

--- a/core/src/StructureTensor.cpp
+++ b/core/src/StructureTensor.cpp
@@ -1,5 +1,7 @@
 #include "vc/core/math/StructureTensor.hpp"
 
+#include <cstddef>
+
 #include <opencv2/imgproc.hpp>
 
 using namespace volcart;
@@ -29,8 +31,8 @@ StructureTensor volcart::ComputeVoxelStructureTensor(
         volume, {vx, vy, vz}, radius, radius, radius);
 
     // Normalize voxel neighbors to [0, 1]
-    for (size_t z = 0; z < v.dz(); ++z) {
-        v.xySlice(z) /= std::numeric_limits<uint16_t>::max();
+    for (std::size_t z = 0; z < v.dz(); ++z) {
+        v.xySlice(z) /= std::numeric_limits<std::uint16_t>::max();
     }
 
     // Get gradient of volume
@@ -39,9 +41,9 @@ StructureTensor volcart::ComputeVoxelStructureTensor(
     // Modulate by gaussian distribution (element-wise) and sum
     auto gaussianField = MakeUniformGaussianField(radius);
     StructureTensor sum(0, 0, 0, 0, 0, 0, 0, 0, 0);
-    for (size_t z = 0; z < v.dz(); ++z) {
-        for (size_t y = 0; y < v.dy(); ++y) {
-            for (size_t x = 0; x < v.dx(); ++x) {
+    for (std::size_t z = 0; z < v.dz(); ++z) {
+        for (std::size_t y = 0; y < v.dy(); ++y) {
+            for (std::size_t x = 0; x < v.dx(); ++x) {
                 sum += gaussianField[z * v.dy() * v.dx() + y * v.dx() + x] *
                        Tensorize(gradientField(x, y, z));
             }
@@ -85,9 +87,9 @@ StructureTensor volcart::ComputeSubvoxelStructureTensor(
     // Modulate by gaussian distribution (element-wise) and sum
     auto gaussianField = MakeUniformGaussianField(radius);
     StructureTensor sum(0, 0, 0, 0, 0, 0, 0, 0, 0);
-    for (size_t z = 0; z < v.dz(); ++z) {
-        for (size_t y = 0; y < v.dy(); ++y) {
-            for (size_t x = 0; x < v.dx(); ++x) {
+    for (std::size_t z = 0; z < v.dz(); ++z) {
+        for (std::size_t y = 0; y < v.dy(); ++y) {
+            for (std::size_t x = 0; x < v.dx(); ++x) {
                 sum += gaussianField[z * v.dy() * v.dx() + y * v.dx() + x] *
                        Tensorize(gradientField(x, y, z));
             }
@@ -204,21 +206,21 @@ Tensor3D<cv::Vec3d> VolumeGradient(const Tensor3D<double>& v, int kernelSize)
     Tensor3D<cv::Vec3d> gradientField{v.dx(), v.dy(), v.dz()};
 
     // First do XY gradients
-    for (size_t z = 0; z < v.dz(); ++z) {
+    for (std::size_t z = 0; z < v.dz(); ++z) {
         auto xGradient = Gradient(v.xySlice(z), Axis::X, kernelSize);
         auto yGradient = Gradient(v.xySlice(z), Axis::Y, kernelSize);
-        for (size_t y = 0; y < v.dy(); ++y) {
-            for (size_t x = 0; x < v.dx(); ++x) {
+        for (std::size_t y = 0; y < v.dy(); ++y) {
+            for (std::size_t x = 0; x < v.dx(); ++x) {
                 gradientField(x, y, z) = {xGradient(y, x), yGradient(y, x), 0};
             }
         }
     }
 
     // Then Z gradients
-    for (size_t layer = 0; layer < v.dy(); ++layer) {
+    for (std::size_t layer = 0; layer < v.dy(); ++layer) {
         auto zGradient = Gradient(v.xzSlice(layer), Axis::Y, kernelSize);
-        for (size_t z = 0; z < v.dz(); ++z) {
-            for (size_t x = 0; x < v.dx(); ++x) {
+        for (std::size_t z = 0; z < v.dz(); ++z) {
+            for (std::size_t x = 0; x < v.dx(); ++x) {
                 gradientField(x, layer, z)(2) = zGradient(z, x);
             }
         }
@@ -268,7 +270,7 @@ cv::Mat_<double> Gradient(const cv::Mat_<double>& input, Axis axis, int ksize)
 
 std::unique_ptr<double[]> MakeUniformGaussianField(int radius)
 {
-    auto sideLength = 2 * static_cast<size_t>(radius) + 1;
+    auto sideLength = 2 * static_cast<std::size_t>(radius) + 1;
     auto fieldSize = sideLength * sideLength * sideLength;
     auto field = std::unique_ptr<double[]>(new double[fieldSize]);
     double sum = 0;
@@ -281,7 +283,7 @@ std::unique_ptr<double[]> MakeUniformGaussianField(int radius)
         for (int y = -radius; y <= radius; ++y) {
             for (int x = -radius; x <= radius; ++x) {
                 double val = std::exp(-(x * x + y * y + z * z));
-                auto index = static_cast<size_t>(
+                auto index = static_cast<std::size_t>(
                     (z + radius) * sideLength * sideLength +
                     (y + radius) * sideLength + (x + radius));
                 field[index] = n * val;
@@ -291,7 +293,7 @@ std::unique_ptr<double[]> MakeUniformGaussianField(int radius)
     }
 
     // Normalize
-    for (size_t i = 0; i < sideLength * sideLength * sideLength; ++i) {
+    for (std::size_t i = 0; i < sideLength * sideLength * sideLength; ++i) {
         field[i] /= sum;
     }
 

--- a/core/src/TIFFIO.cpp
+++ b/core/src/TIFFIO.cpp
@@ -1,5 +1,7 @@
 #include "vc/core/io/TIFFIO.hpp"
 
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 
 #include <opencv2/imgproc.hpp>
@@ -23,8 +25,9 @@ namespace
 // Return a CV Mat type using TIF type (signed, unsigned, float),
 // bit-depth, and number of channels
 auto GetCVMatType(
-    const uint16_t tifType, const uint16_t depth, const uint16_t channels)
-    -> int
+    const std::uint16_t tifType,
+    const std::uint16_t depth,
+    const std::uint16_t channels) -> int
 {
     switch (depth) {
         case 8:
@@ -76,12 +79,12 @@ auto tio::ReadTIFF(const volcart::filesystem::path& path) -> cv::Mat
     }
 
     // Get metadata
-    uint32_t width = 0;
-    uint32_t height = 0;
-    uint16_t type = 1;
-    uint16_t depth = 1;
-    uint16_t channels = 1;
-    uint16_t config = 0;
+    std::uint32_t width = 0;
+    std::uint32_t height = 0;
+    std::uint16_t type = 1;
+    std::uint16_t depth = 1;
+    std::uint16_t channels = 1;
+    std::uint16_t config = 0;
     TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &width);
     TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &height);
     TIFFGetField(tif, TIFFTAG_SAMPLEFORMAT, &type);
@@ -96,7 +99,7 @@ auto tio::ReadTIFF(const volcart::filesystem::path& path) -> cv::Mat
     cv::Mat img = cv::Mat::zeros(h, w, cvType);
 
     // Read the rows
-    auto bufferSize = static_cast<size_t>(lt::TIFFScanlineSize(tif));
+    auto bufferSize = static_cast<std::size_t>(lt::TIFFScanlineSize(tif));
     std::vector<char> buffer(bufferSize + 4);
     if (config == PLANARCONFIG_CONTIG) {
         for (auto row = 0; row < height; row++) {
@@ -253,7 +256,7 @@ void tio::WriteTIFF(
     // TODO: Let user decide associated/unassociated tag
     // See TIFF 6.0 spec, section 18
     if (channels == 2 or channels == 4) {
-        std::array<uint16_t, 1> tag{EXTRASAMPLE_UNASSALPHA};
+        std::array<std::uint16_t, 1> tag{EXTRASAMPLE_UNASSALPHA};
         lt::TIFFSetField(out, TIFFTAG_EXTRASAMPLES, 1, tag.data());
     }
 
@@ -263,7 +266,7 @@ void tio::WriteTIFF(
 
     // Row buffer. OpenCV documentation mentions that TIFFWriteScanline
     // modifies its read buffer, so we can't use the cv::Mat directly
-    auto bufferSize = static_cast<size_t>(lt::TIFFScanlineSize(out));
+    auto bufferSize = static_cast<std::size_t>(lt::TIFFScanlineSize(out));
     std::vector<char> buffer(bufferSize + 32);
 
     // For each row

--- a/core/src/UVMapIO.cpp
+++ b/core/src/UVMapIO.cpp
@@ -1,5 +1,6 @@
 #include "vc/core/io/UVMapIO.hpp"
 
+#include <cstddef>
 #include <fstream>
 #include <regex>
 #include <sstream>
@@ -58,7 +59,7 @@ auto vio::ReadUVMap(const fs::path& path) -> UVMap
         std::string fileType;
         int version;
         std::string type;
-        size_t size;
+        std::size_t size;
         double width{0};
         double height{0};
         int origin{-1};
@@ -169,7 +170,7 @@ auto vio::ReadUVMap(const fs::path& path) -> UVMap
     // Read all of the points
     for (const auto& i : range(h.size)) {
         std::ignore = i;
-        size_t id{0};
+        std::size_t id{0};
         cv::Vec2d uv;
         infile.read(reinterpret_cast<char*>(&id), sizeof(id));
         infile.read(reinterpret_cast<char*>(uv.val), 2 * sizeof(double));

--- a/core/src/Version.cpp.in
+++ b/core/src/Version.cpp.in
@@ -8,21 +8,21 @@ auto ProjectInfo::Name() -> std::string
     return name;
 }
 
-auto ProjectInfo::VersionMajor() -> uint32_t
+auto ProjectInfo::VersionMajor() -> std::uint32_t
 {
-    static uint32_t vMaj{@PROJECT_VERSION_MAJOR@};
+    static std::uint32_t vMaj{@PROJECT_VERSION_MAJOR@};
     return vMaj;
 }
 
-auto ProjectInfo::VersionMinor() -> uint32_t
+auto ProjectInfo::VersionMinor() -> std::uint32_t
 {
-    static uint32_t vMin{@PROJECT_VERSION_MINOR@};
+    static std::uint32_t vMin{@PROJECT_VERSION_MINOR@};
     return vMin;
 }
 
-auto ProjectInfo::VersionPatch() -> uint32_t
+auto ProjectInfo::VersionPatch() -> std::uint32_t
 {
-    static uint32_t vPatch{@PROJECT_VERSION_PATCH@};
+    static std::uint32_t vPatch{@PROJECT_VERSION_PATCH@};
     return vPatch;
 }
 

--- a/core/src/Volume.cpp
+++ b/core/src/Volume.cpp
@@ -70,7 +70,7 @@ void Volume::setSliceHeight(int h)
     metadata_.set("height", h);
 }
 
-void Volume::setNumberOfSlices(size_t numSlices)
+void Volume::setNumberOfSlices(std::size_t numSlices)
 {
     slices_ = numSlices;
     numSliceCharacters_ = std::to_string(numSlices).size();
@@ -129,7 +129,7 @@ void Volume::setSliceData(int index, const cv::Mat& slice, bool compress)
         (compress) ? tiffio::Compression::LZW : tiffio::Compression::NONE);
 }
 
-uint16_t Volume::intensityAt(int x, int y, int z) const
+std::uint16_t Volume::intensityAt(int x, int y, int z) const
 {
     // clang-format off
     if (x < 0 || x >= sliceWidth() ||
@@ -138,12 +138,12 @@ uint16_t Volume::intensityAt(int x, int y, int z) const
         return 0;
     }
     // clang-format on
-    return getSliceData(z).at<uint16_t>(y, x);
+    return getSliceData(z).at<std::uint16_t>(y, x);
 }
 
 // Trilinear Interpolation
 // From: https://en.wikipedia.org/wiki/Trilinear_interpolation
-uint16_t Volume::interpolateAt(double x, double y, double z) const
+std::uint16_t Volume::interpolateAt(double x, double y, double z) const
 {
     // insert safety net
     if (!isInBounds(x, y, z)) {
@@ -174,7 +174,7 @@ uint16_t Volume::interpolateAt(double x, double y, double z) const
     auto c1 = c01 * (1 - dy) + c11 * dy;
 
     auto c = c0 * (1 - dz) + c1 * dz;
-    return static_cast<uint16_t>(cvRound(c));
+    return static_cast<std::uint16_t>(cvRound(c));
 }
 
 Reslice Volume::reslice(
@@ -191,7 +191,7 @@ Reslice Volume::reslice(
     cv::Mat m(height, width, CV_16UC1);
     for (int h = 0; h < height; ++h) {
         for (int w = 0; w < width; ++w) {
-            m.at<uint16_t>(h, w) =
+            m.at<std::uint16_t>(h, w) =
                 interpolateAt(origin + (h * ynorm) + (w * xnorm));
         }
     }

--- a/core/src/VolumeMask.cpp
+++ b/core/src/VolumeMask.cpp
@@ -2,7 +2,8 @@
 
 using namespace volcart;
 
-VolumeMask::VolumeMask(size_t width, size_t height, size_t numSlices)
+VolumeMask::VolumeMask(
+    std::size_t width, std::size_t height, std::size_t numSlices)
     : sliceWidth_{width}, sliceHeight_{height}
 {
 

--- a/core/test/IterationTest.cpp
+++ b/core/test/IterationTest.cpp
@@ -1,6 +1,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstddef>
+
 #include "vc/core/util/Iteration.hpp"
 
 using namespace volcart;
@@ -12,7 +14,7 @@ TEST(Iteration, RangeEndOnly)
     auto it = r.begin();
 
     // Do standard loop
-    for (size_t i = 0; i < 5; i++) {
+    for (std::size_t i = 0; i < 5; i++) {
 
         // Compare to loop indices
         EXPECT_EQ(*it, i);
@@ -29,7 +31,7 @@ TEST(Iteration, RangeStartEnd)
     auto it = r.begin();
 
     // Do standard loop
-    for (size_t i = 1; i < 5; i++) {
+    for (std::size_t i = 1; i < 5; i++) {
 
         // Compare to loop indices
         EXPECT_EQ(*it, i);
@@ -46,7 +48,7 @@ TEST(Iteration, RangeStartEndStep)
     auto it = r.begin();
 
     // Do standard loop
-    for (size_t i = 1; i < 5; i += 2) {
+    for (std::size_t i = 1; i < 5; i += 2) {
 
         // Compare to loop indices
         EXPECT_EQ(*it, i);
@@ -83,8 +85,8 @@ TEST(Iteration, Range2DEndOnly)
     auto it = r.begin();
 
     // Do standard 2D loop
-    for (size_t y = 0; y < 5; y++) {
-        for (size_t x = 0; x < 5; x++) {
+    for (std::size_t y = 0; y < 5; y++) {
+        for (std::size_t x = 0; x < 5; x++) {
 
             // Get iterator value
             auto pair = *it;
@@ -108,8 +110,8 @@ TEST(Iteration, Range2DStartEnd)
     auto it = r.begin();
 
     // Do standard 2D loop
-    for (size_t y = 1; y < 5; y++) {
-        for (size_t x = 1; x < 5; x++) {
+    for (std::size_t y = 1; y < 5; y++) {
+        for (std::size_t x = 1; x < 5; x++) {
 
             // Get iterator value
             auto pair = *it;
@@ -133,8 +135,8 @@ TEST(Iteration, Range2DStartEndStep)
     auto it = r.begin();
 
     // Do standard 2D loop
-    for (size_t y = 1; y < 6; y += 2) {
-        for (size_t x = 1; x < 6; x += 2) {
+    for (std::size_t y = 1; y < 6; y += 2) {
+        for (std::size_t x = 1; x < 6; x += 2) {
 
             // Get iterator value
             auto pair = *it;
@@ -203,7 +205,7 @@ TEST(Iteration, Range2DIteratorEquality)
 TEST(Iteration, EnumerateLVal)
 {
     std::vector<int> values{0, 1, 2, 3, 4};
-    size_t idx{0};
+    std::size_t idx{0};
     for (auto [index, value] : enumerate(values)) {
         EXPECT_EQ(index, idx);
         EXPECT_EQ(value, values[idx]);
@@ -224,7 +226,7 @@ TEST(Iteration, EnumerateLVal)
 TEST(Iteration, EnumerateRVal)
 {
     std::vector<int> truth{0, 1, 2, 3, 4};
-    size_t idx{0};
+    std::size_t idx{0};
     for (const auto [index, value] :
          enumerate(std::vector<int>{0, 1, 2, 3, 4})) {
         EXPECT_EQ(index, idx);
@@ -236,7 +238,7 @@ TEST(Iteration, EnumerateRVal)
 TEST(Iteration, EnumerateParamPack)
 {
     std::vector<int> truth{0, 1, 2, 3, 4};
-    size_t idx{0};
+    std::size_t idx{0};
     for (const auto [index, value] : enumerate(0, 1, 2, 3, 4)) {
         EXPECT_EQ(index, idx);
         EXPECT_EQ(value, truth[idx]);
@@ -247,7 +249,7 @@ TEST(Iteration, EnumerateParamPack)
 TEST(Iteration, EnumerateRange)
 {
     std::vector<int> truth{0, 1, 2, 3, 4};
-    size_t idx{0};
+    std::size_t idx{0};
     for (auto pair : enumerate(range(5))) {
         const auto index = pair.first;
         const auto& value = pair.second;

--- a/core/test/LRUCacheTest.cpp
+++ b/core/test/LRUCacheTest.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <iostream>
 
 #include <gtest/gtest.h>
@@ -9,7 +10,7 @@
 class LRUCache_Empty : public ::testing::Test
 {
 public:
-    volcart::LRUCache<size_t, int> cache;
+    volcart::LRUCache<std::size_t, int> cache;
 };
 
 class LRUCache_Filled : public LRUCache_Empty
@@ -23,7 +24,7 @@ public:
         // fill cache with key ordered from 0-99 and values equaling to key^2
         // cache will push new pairs to front when adding, so final list order
         // will be 99,98,...,0
-        for (size_t idx = 0; idx < cache.capacity(); idx++) {
+        for (std::size_t idx = 0; idx < cache.capacity(); idx++) {
 
             // set the cache item pairs
             cache.put(idx, (idx * idx));
@@ -53,7 +54,7 @@ TEST_F(LRUCache_Empty, ResizeCapacity)
 TEST_F(LRUCache_Filled, CheckReferenceToOutOfBoundsKey)
 {
     EXPECT_EQ(cache.capacity(), cache.size());
-    for (size_t key = 0; key < cache.capacity(); key++) {
+    for (std::size_t key = 0; key < cache.capacity(); key++) {
         EXPECT_EQ(cache.get(key), key * key);
     }
 
@@ -100,7 +101,7 @@ TEST_F(LRUCache_Empty, CheckCacheWithDifferingCapacityAndSize)
     EXPECT_EQ(cache.capacity(), 200);
     EXPECT_EQ(cache.size(), 0);
 
-    for (size_t key = 0; key < cache.capacity(); key += 2) {
+    for (std::size_t key = 0; key < cache.capacity(); key += 2) {
         // add even numbers, zero inclusive, and double their key as the value
         // will add items in descending key value order --> 198,196...,2,0
         cache.put(key, key + key);
@@ -111,7 +112,7 @@ TEST_F(LRUCache_Empty, CheckCacheWithDifferingCapacityAndSize)
 
     // test to see what happens when referencing an odd-number key
     // also, checking if oddKey exists --> redundant
-    for (size_t oddKey = 1; oddKey < cache.capacity(); oddKey += 2) {
+    for (std::size_t oddKey = 1; oddKey < cache.capacity(); oddKey += 2) {
         try {
             EXPECT_EQ(cache.contains(oddKey), false);
             EXPECT_ANY_THROW(cache.get(oddKey));
@@ -123,7 +124,7 @@ TEST_F(LRUCache_Empty, CheckCacheWithDifferingCapacityAndSize)
     // of the cache, thus, we'll check item key 98,96,...,2,0
     cache.setCapacity(50);
 
-    for (size_t k = 0; k < cache.capacity() * 2; k += 2) {
+    for (std::size_t k = 0; k < cache.capacity() * 2; k += 2) {
         try {
             EXPECT_EQ(cache.contains(k), false);
             EXPECT_ANY_THROW(cache.get(k));
@@ -146,7 +147,7 @@ TEST_F(LRUCache_Empty, TryToInsertMorePairsThanCurrentCapacity)
     EXPECT_EQ(cache.capacity(), 200);
     EXPECT_EQ(cache.size(), 0);
 
-    for (size_t key = 0; key <= cache.capacity(); key++) {
+    for (std::size_t key = 0; key <= cache.capacity(); key++) {
         cache.put(key, key + key);
     }
 

--- a/core/test/OBJWriterTest.cpp
+++ b/core/test/OBJWriterTest.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cstddef>
+
 #include "vc/core/io/OBJWriter.hpp"
 #include "vc/core/shapes/Plane.hpp"
 #include "vc/core/types/SimpleMesh.hpp"
@@ -41,7 +43,7 @@ TEST_F(OBJWriter, UntexturedMesh)
     EXPECT_EQ(mesh->GetNumberOfCells(), saved.faces.size());
 
     // Check vertex values
-    size_t idx = 0;
+    std::size_t idx = 0;
     vc::ITKPixel origN;
     for (const auto& v : saved.verts) {
         // Check 3D Position

--- a/core/test/PLYReaderTest.cpp
+++ b/core/test/PLYReaderTest.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cstdint>
+
 #include "vc/core/io/PLYReader.hpp"
 #include "vc/core/io/PLYWriter.hpp"
 #include "vc/core/shapes/Arch.hpp"
@@ -89,7 +91,7 @@ TEST_F(ReadITKArchMeshFixture, ReadArchMeshTest)
         _in_ArchMesh->GetNumberOfPoints(), _read_ArchMesh->GetNumberOfPoints());
     EXPECT_EQ(
         _in_ArchMesh->GetNumberOfCells(), _read_ArchMesh->GetNumberOfCells());
-    for (uint64_t pnt_id = 0; pnt_id < _in_ArchMesh->GetNumberOfPoints();
+    for (std::uint64_t pnt_id = 0; pnt_id < _in_ArchMesh->GetNumberOfPoints();
          pnt_id++) {
         volcart::testing::SmallOrClose(
             _in_ArchMesh->GetPoint(pnt_id)[0],
@@ -112,7 +114,7 @@ TEST_F(ReadITKArchMeshFixture, ReadArchMeshTest)
         volcart::testing::SmallOrClose(in_normal[2], read_normal[2]);
     }
 
-    for (uint64_t cell_id = 0; cell_id < _in_ArchMesh->GetNumberOfCells();
+    for (std::uint64_t cell_id = 0; cell_id < _in_ArchMesh->GetNumberOfCells();
          cell_id++) {
         volcart::ITKCell::CellAutoPointer in_C;
         _in_ArchMesh->GetCell(cell_id, in_C);
@@ -134,7 +136,7 @@ TEST_F(ReadITKPlaneMeshFixture, ReadPlaneMeshTest)
         _read_PlaneMesh->GetNumberOfPoints());
     EXPECT_EQ(
         _in_PlaneMesh->GetNumberOfCells(), _read_PlaneMesh->GetNumberOfCells());
-    for (uint64_t pnt_id = 0; pnt_id < _in_PlaneMesh->GetNumberOfPoints();
+    for (std::uint64_t pnt_id = 0; pnt_id < _in_PlaneMesh->GetNumberOfPoints();
          pnt_id++) {
         volcart::testing::SmallOrClose(
             _in_PlaneMesh->GetPoint(pnt_id)[0],
@@ -157,7 +159,7 @@ TEST_F(ReadITKPlaneMeshFixture, ReadPlaneMeshTest)
         volcart::testing::SmallOrClose(in_normal[2], read_normal[2]);
     }
 
-    for (uint64_t cell_id = 0; cell_id < _in_PlaneMesh->GetNumberOfCells();
+    for (std::uint64_t cell_id = 0; cell_id < _in_PlaneMesh->GetNumberOfCells();
          cell_id++) {
         volcart::ITKCell::CellAutoPointer in_C;
         _in_PlaneMesh->GetCell(cell_id, in_C);
@@ -178,7 +180,7 @@ TEST_F(ReadITKConeMeshFixture, ReadConeMeshTest)
         _in_ConeMesh->GetNumberOfPoints(), _read_ConeMesh->GetNumberOfPoints());
     EXPECT_EQ(
         _in_ConeMesh->GetNumberOfCells(), _read_ConeMesh->GetNumberOfCells());
-    for (uint64_t pnt_id = 0; pnt_id < _in_ConeMesh->GetNumberOfPoints();
+    for (std::uint64_t pnt_id = 0; pnt_id < _in_ConeMesh->GetNumberOfPoints();
          pnt_id++) {
         volcart::testing::SmallOrClose(
             _in_ConeMesh->GetPoint(pnt_id)[0],
@@ -201,7 +203,7 @@ TEST_F(ReadITKConeMeshFixture, ReadConeMeshTest)
         volcart::testing::SmallOrClose(in_normal[2], read_normal[2]);
     }
 
-    for (uint64_t cell_id = 0; cell_id < _in_ConeMesh->GetNumberOfCells();
+    for (std::uint64_t cell_id = 0; cell_id < _in_ConeMesh->GetNumberOfCells();
          cell_id++) {
         volcart::ITKCell::CellAutoPointer in_C;
         _in_ConeMesh->GetCell(cell_id, in_C);
@@ -224,7 +226,7 @@ TEST_F(ReadITKSphereMeshFixture, ReadSphereMeshTest)
     EXPECT_EQ(
         _in_SphereMesh->GetNumberOfCells(),
         _read_SphereMesh->GetNumberOfCells());
-    for (uint64_t pnt_id = 0; pnt_id < _in_SphereMesh->GetNumberOfPoints();
+    for (std::uint64_t pnt_id = 0; pnt_id < _in_SphereMesh->GetNumberOfPoints();
          pnt_id++) {
         volcart::testing::SmallOrClose(
             _in_SphereMesh->GetPoint(pnt_id)[0],
@@ -247,8 +249,8 @@ TEST_F(ReadITKSphereMeshFixture, ReadSphereMeshTest)
         volcart::testing::SmallOrClose(in_normal[2], read_normal[2]);
     }
 
-    for (uint64_t cell_id = 0; cell_id < _in_SphereMesh->GetNumberOfCells();
-         cell_id++) {
+    for (std::uint64_t cell_id = 0;
+         cell_id < _in_SphereMesh->GetNumberOfCells(); cell_id++) {
         volcart::ITKCell::CellAutoPointer in_C;
         _in_SphereMesh->GetCell(cell_id, in_C);
         volcart::ITKCell::CellAutoPointer read_C;

--- a/core/test/PLYWriterTest.cpp
+++ b/core/test/PLYWriterTest.cpp
@@ -41,7 +41,7 @@ TEST_F(PLYWriter, UntexturedMesh)
     EXPECT_EQ(mesh->GetNumberOfCells(), saved.faces.size());
 
     // Check vertex values
-    size_t idx = 0;
+    std::size_t idx = 0;
     vc::ITKPixel origN;
     for (const auto& v : saved.verts) {
         // Check 3D Position

--- a/core/test/PerPixelMapTest.cpp
+++ b/core/test/PerPixelMapTest.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cstdint>
+
 #include "vc/core/types/PerPixelMap.hpp"
 
 using namespace volcart;

--- a/core/test/PointSetTest.cpp
+++ b/core/test/PointSetTest.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cstddef>
+
 #include <opencv2/core.hpp>
 
 #include "vc/core/types/PointSet.hpp"
@@ -38,7 +40,7 @@ TEST_F(Vec3iPointSet, OneRowPointSetIteratorTest)
     EXPECT_EQ(ps.back(), cv::Vec3i(3, 3, 3));
     EXPECT_EQ(*std::begin(ps), cv::Vec3i(1, 1, 1));
     EXPECT_EQ(*(std::end(ps) - 1), cv::Vec3i(3, 3, 3));
-    size_t i = 1;
+    std::size_t i = 1;
     for (auto p : ps) {
         EXPECT_EQ(p, cv::Vec3i(i, i, i));
         ++i;

--- a/core/test/SignalsTest.cpp
+++ b/core/test/SignalsTest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <iostream>
 
 #include "vc/core/util/Signals.hpp"
@@ -172,11 +173,11 @@ TEST(Signals, PointerParameterFn)
 
 TEST(Signals, Sendlval)
 {
-    size_t val{0};
-    Signal<size_t> signal;
-    signal.connect([&val](size_t v) { val = v; });
+    std::size_t val{0};
+    Signal<std::size_t> signal;
+    signal.connect([&val](std::size_t v) { val = v; });
 
-    size_t i{1};
+    std::size_t i{1};
     signal(i);
 
     EXPECT_EQ(val, 1);

--- a/core/test/TIFFIOTest.cpp
+++ b/core/test/TIFFIOTest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <limits>
 #include <random>
 

--- a/core/test/UVMapTest.cpp
+++ b/core/test/UVMapTest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <iostream>
 
 #include "vc/core/io/UVMapIO.hpp"
@@ -141,8 +142,8 @@ TEST(UVMapTest, WriteAndRead)
     cv::RNG rng(std::time(nullptr));
     uvMap.setOrigin(static_cast<UVMap::Origin>(rng.uniform(0, 4)));
     auto size = static_cast<std::size_t>(rng.uniform(100, 1000));
-    for (size_t i = 0; i < size; i++) {
-        size_t id = rng.uniform(0, size);
+    for (std::size_t i = 0; i < size; i++) {
+        std::size_t id = rng.uniform(0, size);
         auto u = rng.uniform(0.0, 1.0);
         auto v = rng.uniform(0.0, 1.0);
         uvMap.set(id, {u, v});

--- a/examples/src/ApplyTransformsExample.cpp
+++ b/examples/src/ApplyTransformsExample.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+
 #include "vc/core/io/MeshIO.hpp"
 #include "vc/core/io/PointSetIO.hpp"
 #include "vc/core/shapes/Cube.hpp"

--- a/examples/src/TextureExample.cpp
+++ b/examples/src/TextureExample.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+
 #include "vc/core/io/MeshIO.hpp"
 #include "vc/core/neighborhood/LineGenerator.hpp"
 #include "vc/core/types/VolumePkg.hpp"
@@ -17,8 +19,8 @@ int main(int /*argc*/, char* argv[])
     mesher.setPointSet(seg->getPointSet());
     auto inputMesh = mesher.compute();
 
-    size_t width = 608 * 2;
-    size_t height = 370 * 2;
+    std::size_t width = 608 * 2;
+    std::size_t height = 370 * 2;
 
     auto uvMap = vc::UVMap::New();
     uvMap->set(0, cv::Vec2d(0, 0));

--- a/graph/include/vc/graph/core.hpp
+++ b/graph/include/vc/graph/core.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 #include <opencv2/core.hpp>
 #include <smgl/Node.hpp>
 

--- a/graph/include/vc/graph/meshing.hpp
+++ b/graph/include/vc/graph/meshing.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 #include <smgl/Node.hpp>
 
 #include "vc/core/filesystem.hpp"

--- a/graph/include/vc/graph/texturing.hpp
+++ b/graph/include/vc/graph/texturing.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstdint>
 #include <limits>
 
 #include <opencv2/core.hpp>
@@ -470,7 +471,7 @@ public:
     /** @copybrief texturing::IntegralTexture::setClampValuesToMax() */
     smgl::InputPort<bool> clampValuesToMax;
     /** @copybrief texturing::IntegralTexture::setClampMax() */
-    smgl::InputPort<uint16_t> clampMax;
+    smgl::InputPort<std::uint16_t> clampMax;
     /** @copybrief texturing::IntegralTexture::setWeightMethod() */
     smgl::InputPort<WeightMethod> weightMethod;
     /** @copybrief texturing::IntegralTexture::setLinearWeightDirection() */

--- a/graph/src/core.cpp
+++ b/graph/src/core.cpp
@@ -130,7 +130,7 @@ auto VolumePropertiesNode::serialize_(
 void VolumePropertiesNode::deserialize_(
     const smgl::Metadata& meta, const filesystem::path& /*cacheDir*/)
 {
-    cacheMem_ = meta["cacheMemory"].get<size_t>();
+    cacheMem_ = meta["cacheMemory"].get<std::size_t>();
 }
 
 SegmentationSelectorNode::SegmentationSelectorNode()

--- a/graph/src/meshing.cpp
+++ b/graph/src/meshing.cpp
@@ -116,7 +116,7 @@ CalculateNumVertsNode::CalculateNumVertsNode()
         static constexpr std::size_t MIN_NUM{100};
         auto sqVoxel = voxelSize_ * voxelSize_;
         auto a = SurfaceArea(mesh_) * sqVoxel * UM_TO_MM;
-        numVerts_ = std::max(static_cast<size_t>(density_ * a), MIN_NUM);
+        numVerts_ = std::max(static_cast<std::size_t>(density_ * a), MIN_NUM);
     };
 }
 
@@ -134,7 +134,7 @@ void CalculateNumVertsNode::deserialize_(
 {
     density_ = meta["density"].get<double>();
     voxelSize_ = meta["voxelSize"].get<double>();
-    numVerts_ = meta["numVerts"].get<size_t>();
+    numVerts_ = meta["numVerts"].get<std::size_t>();
 }
 
 LaplacianSmoothMeshNode::LaplacianSmoothMeshNode()

--- a/graph/src/texturing.cpp
+++ b/graph/src/texturing.cpp
@@ -1,5 +1,6 @@
 #include "vc/graph/texturing.hpp"
 
+#include <cstddef>
 #include <memory>
 
 #include <nlohmann/json.hpp>
@@ -274,8 +275,8 @@ PPMGeneratorNode::PPMGeneratorNode()
     : Node{true}
     , mesh{&ppmGen_, &PPMGen::setMesh}
     , uvMap{[&](const auto& uv) {
-        auto width = static_cast<size_t>(std::ceil(uv->ratio().width));
-        auto height = static_cast<size_t>(std::ceil(uv->ratio().height));
+        auto width = static_cast<std::size_t>(std::ceil(uv->ratio().width));
+        auto height = static_cast<std::size_t>(std::ceil(uv->ratio().height));
         ppmGen_.setUVMap(uv);
         ppmGen_.setDimensions(height, width);
     }}
@@ -539,7 +540,7 @@ void IntegralTextureNode::deserialize_(
     const smgl::Metadata& meta, const fs::path& cacheDir)
 {
     textureGen_.setClampValuesToMax(meta["clampToMax"].get<bool>());
-    textureGen_.setClampMax(meta["clampMax"].get<uint16_t>());
+    textureGen_.setClampMax(meta["clampMax"].get<std::uint16_t>());
     textureGen_.setWeightMethod(meta["weightMethod"].get<WeightMethod>());
     textureGen_.setLinearWeightDirection(
         meta["linearWeightDirection"].get<WeightDirection>());

--- a/meshing/include/vc/meshing/ACVD.hpp
+++ b/meshing/include/vc/meshing/ACVD.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 #include "vc/core/types/ITKMesh.hpp"
 
 namespace volcart::meshing

--- a/meshing/include/vc/meshing/LaplacianSmooth.hpp
+++ b/meshing/include/vc/meshing/LaplacianSmooth.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 #include "vc/core/types/ITKMesh.hpp"
 
 namespace volcart::meshing

--- a/meshing/include/vc/meshing/OrderedPointSetMesher.hpp
+++ b/meshing/include/vc/meshing/OrderedPointSetMesher.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 #include <opencv2/core.hpp>
 
 #include "vc/core/types/ITKMesh.hpp"
@@ -83,6 +85,6 @@ private:
      * @param b ID for the second vertex in the face
      * @param c ID for the third vertex in the face
      */
-    void add_cell_(size_t a, size_t b, size_t c);
+    void add_cell_(std::size_t a, std::size_t b, std::size_t c);
 };
 }  // namespace volcart::meshing

--- a/meshing/include/vc/meshing/OrderedResampling.hpp
+++ b/meshing/include/vc/meshing/OrderedResampling.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstdint>
 #include <iostream>
 #include <stdexcept>
 #include <vector>
@@ -106,6 +107,6 @@ private:
      * @param b ID for the second vertex in the face
      * @param c ID for the third vertex in the face
      */
-    void add_cell_(uint32_t a, uint32_t b, uint32_t c);
+    void add_cell_(std::uint32_t a, std::uint32_t b, std::uint32_t c);
 };
 }  // namespace volcart::meshing

--- a/meshing/src/ACVD.cpp
+++ b/meshing/src/ACVD.cpp
@@ -22,13 +22,16 @@ void ACVD::setInputMesh(ITKMesh::Pointer input)
 
 void ACVD::setMode(Mode m) { mode_ = m; }
 
-void ACVD::setNumberOfClusters(size_t n) { clusters_ = n; }
+void ACVD::setNumberOfClusters(std::size_t n) { clusters_ = n; }
 
 void ACVD::setGradation(double g) { gradation_ = g; }
 
-void ACVD::setSubsampleThreshold(size_t t) { subsampleThreshold_ = t; }
+void ACVD::setSubsampleThreshold(std::size_t t) { subsampleThreshold_ = t; }
 
-void ACVD::setQuadricsOptimizationLevel(size_t l) { quadricsOptLevel_ = l; }
+void ACVD::setQuadricsOptimizationLevel(std::size_t l)
+{
+    quadricsOptLevel_ = l;
+}
 
 ITKMesh::Pointer ACVD::getOutputMesh() const { return outputMesh_; }
 

--- a/meshing/src/CalculateNormals.cpp
+++ b/meshing/src/CalculateNormals.cpp
@@ -1,5 +1,7 @@
 #include "vc/meshing/CalculateNormals.hpp"
 
+#include <cstdint>
+
 using namespace volcart;
 using namespace volcart::meshing;
 
@@ -35,7 +37,7 @@ void CalculateNormals::compute_normals_()
         cv::Vec3d v0, v1, v2, e0, e1;
 
         // Collect the point id's for this cell
-        std::vector<uint64_t> pointIds;
+        std::vector<std::uint64_t> pointIds;
         ITKPoint vert;
         for (auto p = cellIt->Value()->PointIdsBegin();
              p != cellIt->Value()->PointIdsEnd(); ++p) {

--- a/meshing/src/OrderedPointSetMesher.cpp
+++ b/meshing/src/OrderedPointSetMesher.cpp
@@ -18,7 +18,7 @@ volcart::ITKMesh::Pointer OrderedPointSetMesher::compute()
 
     // Transfer the vertex info
     ITKPoint tmpPt;
-    size_t cnt = 0;
+    std::size_t cnt = 0;
     for (auto& i : input_) {
         tmpPt[0] = i[0];
         tmpPt[1] = i[1];
@@ -34,9 +34,9 @@ volcart::ITKMesh::Pointer OrderedPointSetMesher::compute()
     }
 
     // Creates 2 cells per iteration and adds them to the mesh
-    size_t p0, p1, p2, p3;
-    for (size_t i = 0; i < input_.height() - 1; i++) {
-        for (size_t j = 0; j < input_.width() - 1; j++) {
+    std::size_t p0, p1, p2, p3;
+    for (std::size_t i = 0; i < input_.height() - 1; i++) {
+        for (std::size_t j = 0; j < input_.width() - 1; j++) {
 
             // Get the indices for the faces adjacent along the "hypotenuse"
             p0 = i * input_.width() + j;
@@ -67,7 +67,8 @@ volcart::ITKMesh::Pointer OrderedPointSetMesher::compute()
     return output_;
 }
 
-void OrderedPointSetMesher::add_cell_(size_t a, size_t b, size_t c)
+void OrderedPointSetMesher::add_cell_(
+    std::size_t a, std::size_t b, std::size_t c)
 {
     ITKCell::CellAutoPointer currentC;
 

--- a/meshing/src/OrderedResampling.cpp
+++ b/meshing/src/OrderedResampling.cpp
@@ -1,6 +1,9 @@
 /* @file OrderedResampling.cpp*/
 
 #include "vc/meshing/OrderedResampling.hpp"
+
+#include <cstdint>
+
 #include "vc/core/util/Logging.hpp"
 #include "vc/meshing/CalculateNormals.hpp"
 
@@ -70,7 +73,7 @@ void OrderedResampling::compute()
         "Error resampling. Output and expected output don't match.");
 
     // Vertices for each face in the new mesh
-    uint32_t point1, point2, point3, point4;
+    std::uint32_t point1, point2, point3, point4;
 
     // Create two new faces each iteration based on new set of points and keeps
     // normals same as original
@@ -111,7 +114,8 @@ void OrderedResampling::compute()
         std::to_string(output_->GetNumberOfCells()));
 }
 
-void OrderedResampling::add_cell_(uint32_t a, uint32_t b, uint32_t c)
+void OrderedResampling::add_cell_(
+    std::uint32_t a, std::uint32_t b, std::uint32_t c)
 {
     ITKCell::CellAutoPointer currentCell;
 

--- a/meshing/test/ITK2VTKTest.cpp
+++ b/meshing/test/ITK2VTKTest.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cstddef>
+
 #include "vc/core/shapes/Arch.hpp"
 #include "vc/core/shapes/Cone.hpp"
 #include "vc/core/shapes/Cube.hpp"
@@ -585,7 +587,8 @@ TEST_F(
     EXPECT_EQ(_SavedPoints.size(), _out_Mesh->GetNumberOfPoints());
 
     // Check equivalency of points
-    for (size_t pnt_id = 0; pnt_id < _out_Mesh->GetNumberOfPoints(); ++pnt_id) {
+    for (std::size_t pnt_id = 0; pnt_id < _out_Mesh->GetNumberOfPoints();
+         ++pnt_id) {
         volcart::testing::SmallOrClose(
             _out_Mesh->GetPoint(pnt_id)[0], _SavedPoints[pnt_id].x);
         volcart::testing::SmallOrClose(
@@ -649,7 +652,8 @@ TEST_F(
     EXPECT_EQ(_SavedPoints.size(), _out_Mesh->GetNumberOfPoints());
 
     // Check equivalency of points
-    for (size_t pnt_id = 0; pnt_id < _out_Mesh->GetNumberOfPoints(); ++pnt_id) {
+    for (std::size_t pnt_id = 0; pnt_id < _out_Mesh->GetNumberOfPoints();
+         ++pnt_id) {
         volcart::testing::SmallOrClose(
             _out_Mesh->GetPoint(pnt_id)[0], _SavedPoints[pnt_id].x);
         volcart::testing::SmallOrClose(
@@ -704,7 +708,8 @@ TEST_F(
     EXPECT_EQ(_SavedPoints.size(), _out_Mesh->GetNumberOfPoints());
 
     // Check equivalency of points
-    for (size_t pnt_id = 0; pnt_id < _out_Mesh->GetNumberOfPoints(); ++pnt_id) {
+    for (std::size_t pnt_id = 0; pnt_id < _out_Mesh->GetNumberOfPoints();
+         ++pnt_id) {
         volcart::testing::SmallOrClose(
             _out_Mesh->GetPoint(pnt_id)[0], _SavedPoints[pnt_id].x);
         volcart::testing::SmallOrClose(
@@ -759,7 +764,8 @@ TEST_F(
     EXPECT_EQ(_SavedPoints.size(), _out_Mesh->GetNumberOfPoints());
 
     // Check equivalency of points
-    for (size_t pnt_id = 0; pnt_id < _out_Mesh->GetNumberOfPoints(); ++pnt_id) {
+    for (std::size_t pnt_id = 0; pnt_id < _out_Mesh->GetNumberOfPoints();
+         ++pnt_id) {
         volcart::testing::SmallOrClose(
             _out_Mesh->GetPoint(pnt_id)[0], _SavedPoints[pnt_id].x);
         volcart::testing::SmallOrClose(
@@ -814,7 +820,8 @@ TEST_F(
     EXPECT_EQ(_SavedPoints.size(), _out_Mesh->GetNumberOfPoints());
 
     // Check equivalency of points
-    for (size_t pnt_id = 0; pnt_id < _out_Mesh->GetNumberOfPoints(); ++pnt_id) {
+    for (std::size_t pnt_id = 0; pnt_id < _out_Mesh->GetNumberOfPoints();
+         ++pnt_id) {
         volcart::testing::SmallOrClose(
             _out_Mesh->GetPoint(pnt_id)[0], _SavedPoints[pnt_id].x);
         volcart::testing::SmallOrClose(

--- a/meshing/test/OrderedPointSetMesherTest.cpp
+++ b/meshing/test/OrderedPointSetMesherTest.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cstdint>
+
 #include <opencv2/core.hpp>
 
 #include "vc/core/io/OBJWriter.hpp"
@@ -109,7 +111,7 @@ TEST_F(OrderedPlaneFixture, MeshedPlaneTest)
 
     // Check Points and Normals
     EXPECT_EQ(_out_Mesh->GetNumberOfPoints(), _SavedPoints.size());
-    for (uint64_t pnt_id = 0; pnt_id < _SavedPoints.size(); pnt_id++) {
+    for (std::uint64_t pnt_id = 0; pnt_id < _SavedPoints.size(); pnt_id++) {
         volcart::testing::SmallOrClose(
             _out_Mesh->GetPoint(pnt_id)[0], _SavedPoints[pnt_id].x);
         volcart::testing::SmallOrClose(
@@ -129,7 +131,7 @@ TEST_F(OrderedPlaneFixture, MeshedPlaneTest)
     // Check Cells, Checks Point normals by ensuring that the first vertex is
     // the same in both
     EXPECT_EQ(_SavedCells.size(), _out_Mesh->GetNumberOfCells());
-    for (uint64_t cell_id = 0; cell_id < _SavedCells.size(); cell_id++) {
+    for (std::uint64_t cell_id = 0; cell_id < _SavedCells.size(); cell_id++) {
         ITKCell::CellAutoPointer current_C;
         _out_Mesh->GetCell(cell_id, current_C);
         EXPECT_EQ(current_C->GetPointIds()[0], _SavedCells[cell_id].v1);
@@ -146,7 +148,7 @@ TEST_F(OrderedArchFixture, MeshedArchTest)
 
     // Check Points and Normals
     EXPECT_EQ(_out_Mesh->GetNumberOfPoints(), _SavedPoints.size());
-    for (uint64_t pnt_id = 0; pnt_id < _SavedPoints.size(); pnt_id++) {
+    for (std::uint64_t pnt_id = 0; pnt_id < _SavedPoints.size(); pnt_id++) {
         volcart::testing::SmallOrClose(
             _out_Mesh->GetPoint(pnt_id)[0], _SavedPoints[pnt_id].x);
         volcart::testing::SmallOrClose(
@@ -166,7 +168,7 @@ TEST_F(OrderedArchFixture, MeshedArchTest)
     // Check Cells, Checks Point normals by ensuring that the first vertex is
     // the same in both
     EXPECT_EQ(_SavedCells.size(), _out_Mesh->GetNumberOfCells());
-    for (uint64_t cell_id = 0; cell_id < _SavedCells.size(); cell_id++) {
+    for (std::uint64_t cell_id = 0; cell_id < _SavedCells.size(); cell_id++) {
         ITKCell::CellAutoPointer current_C;
         _out_Mesh->GetCell(cell_id, current_C);
         EXPECT_EQ(current_C->GetPointIds()[0], _SavedCells[cell_id].v1);

--- a/meshing/test/OrderedResamplingTest.cpp
+++ b/meshing/test/OrderedResamplingTest.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cstdint>
+
 #include "vc/core/shapes/Arch.hpp"
 #include "vc/core/shapes/Plane.hpp"
 #include "vc/core/types/SimpleMesh.hpp"
@@ -56,7 +58,7 @@ TEST_F(OrderedPlaneFixture, ResampledPlaneTest)
 
     // Check Points and Normals
     EXPECT_EQ(_out_Mesh->GetNumberOfPoints(), _SavedPoints.size());
-    for (uint64_t pnt_id = 0; pnt_id < _SavedPoints.size(); pnt_id++) {
+    for (std::uint64_t pnt_id = 0; pnt_id < _SavedPoints.size(); pnt_id++) {
         volcart::testing::SmallOrClose(
             _out_Mesh->GetPoint(pnt_id)[0], _SavedPoints[pnt_id].x);
         volcart::testing::SmallOrClose(
@@ -76,7 +78,7 @@ TEST_F(OrderedPlaneFixture, ResampledPlaneTest)
     // Check Cells, Checks Point normals by ensuring that the first vertex is
     // the same in both
     EXPECT_EQ(_SavedCells.size(), _out_Mesh->GetNumberOfCells());
-    for (uint64_t cell_id = 0; cell_id < _SavedCells.size(); cell_id++) {
+    for (std::uint64_t cell_id = 0; cell_id < _SavedCells.size(); cell_id++) {
         ITKCell::CellAutoPointer current_C;
         _out_Mesh->GetCell(cell_id, current_C);
         EXPECT_EQ(current_C->GetPointIds()[0], _SavedCells[cell_id].v1);
@@ -94,7 +96,7 @@ TEST_F(OrderedArchFixture, ResampledArchTest)
 
     // Check Points and Normals
     EXPECT_EQ(_out_Mesh->GetNumberOfPoints(), _SavedPoints.size());
-    for (uint64_t pnt_id = 0; pnt_id < _SavedPoints.size(); pnt_id++) {
+    for (std::uint64_t pnt_id = 0; pnt_id < _SavedPoints.size(); pnt_id++) {
         volcart::testing::SmallOrClose(
             _out_Mesh->GetPoint(pnt_id)[0], _SavedPoints[pnt_id].x);
         volcart::testing::SmallOrClose(
@@ -114,7 +116,7 @@ TEST_F(OrderedArchFixture, ResampledArchTest)
     // Check Cells, Checks Point normals by ensuring that the first vertex is
     // the same in both
     EXPECT_EQ(_SavedCells.size(), _out_Mesh->GetNumberOfCells());
-    for (uint64_t cell_id = 0; cell_id < _SavedCells.size(); cell_id++) {
+    for (std::uint64_t cell_id = 0; cell_id < _SavedCells.size(); cell_id++) {
         ITKCell::CellAutoPointer current_C;
         _out_Mesh->GetCell(cell_id, current_C);
         EXPECT_EQ(current_C->GetPointIds()[0], _SavedCells[cell_id].v1);

--- a/meshing/test/ScaleMeshTest.cpp
+++ b/meshing/test/ScaleMeshTest.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cstddef>
+
 #include "vc/core/io/OBJWriter.hpp"
 #include "vc/core/shapes/Arch.hpp"
 #include "vc/core/shapes/Cone.hpp"
@@ -170,7 +172,7 @@ TEST_F(ScaledPlaneFixture, ScaledPlaneTest)
             _in_PlaneMesh->GetNumberOfPoints(),
             _out_PlaneMesh->GetNumberOfPoints());
 
-        for (size_t point = 0; point < _out_PlaneMesh->GetNumberOfPoints();
+        for (std::size_t point = 0; point < _out_PlaneMesh->GetNumberOfPoints();
              ++point) {
 
             // check each of the points in the input and output meshes to
@@ -203,7 +205,7 @@ TEST_F(ScaledCubeFixture, ScaledCubeTest)
             _in_CubeMesh->GetNumberOfPoints(),
             _out_CubeMesh->GetNumberOfPoints());
 
-        for (size_t point = 0; point < _out_CubeMesh->GetNumberOfPoints();
+        for (std::size_t point = 0; point < _out_CubeMesh->GetNumberOfPoints();
              ++point) {
 
             volcart::testing::SmallOrClose(
@@ -232,7 +234,7 @@ TEST_F(ScaledArchFixture, ScaledArchTest)
             _in_ArchMesh->GetNumberOfPoints(),
             _out_ArchMesh->GetNumberOfPoints());
 
-        for (size_t point = 0; point < _out_ArchMesh->GetNumberOfPoints();
+        for (std::size_t point = 0; point < _out_ArchMesh->GetNumberOfPoints();
              ++point) {
 
             volcart::testing::SmallOrClose(
@@ -262,8 +264,8 @@ TEST_F(ScaledSphereFixture, ScaledSphereTest)
             _in_SphereMesh->GetNumberOfPoints(),
             _out_SphereMesh->GetNumberOfPoints());
 
-        for (size_t point = 0; point < _out_SphereMesh->GetNumberOfPoints();
-             ++point) {
+        for (std::size_t point = 0;
+             point < _out_SphereMesh->GetNumberOfPoints(); ++point) {
 
             volcart::testing::SmallOrClose(
                 _in_SphereMesh->GetPoint(point)[0] * _ScaleFactor,
@@ -291,7 +293,7 @@ TEST_F(ScaledConeFixture, ScaledConeTest)
             _in_ConeMesh->GetNumberOfPoints(),
             _out_ConeMesh->GetNumberOfPoints());
 
-        for (size_t point = 0; point < _out_ConeMesh->GetNumberOfPoints();
+        for (std::size_t point = 0; point < _out_ConeMesh->GetNumberOfPoints();
              ++point) {
 
             volcart::testing::SmallOrClose(
@@ -330,7 +332,7 @@ TEST_F(ScaledPlaneFixture, ConfirmInputPlaneMeshIsUnchangedAfterScalingTest)
     EXPECT_EQ(
         _in_PlaneMesh->GetNumberOfCells(), NewPlaneMesh->GetNumberOfCells());
 
-    for (size_t point = 0; point < _in_PlaneMesh->GetNumberOfPoints();
+    for (std::size_t point = 0; point < _in_PlaneMesh->GetNumberOfPoints();
          ++point) {
 
         EXPECT_EQ(
@@ -391,7 +393,7 @@ TEST_F(ScaledPlaneFixture, CompareSavedAndFixtureScaledPlaneMesh)
         _SavedPlaneCells.size());
 
     // points
-    for (size_t point = 0; point < _SavedPlanePoints.size(); ++point) {
+    for (std::size_t point = 0; point < _SavedPlanePoints.size(); ++point) {
 
         EXPECT_EQ(
             _out_PlaneMeshUsedForRegressionTest->GetPoint(point)[0],
@@ -484,7 +486,7 @@ TEST_F(ScaledCubeFixture, CompareSavedAndFixtureScaledCubeMesh)
         _out_CubeMeshUsedForRegressionTest->GetNumberOfCells(),
         _SavedCubeCells.size());
 
-    for (size_t point = 0; point < _SavedCubePoints.size(); ++point) {
+    for (std::size_t point = 0; point < _SavedCubePoints.size(); ++point) {
 
         EXPECT_EQ(
             _out_CubeMeshUsedForRegressionTest->GetPoint(point)[0],
@@ -564,7 +566,7 @@ TEST_F(ScaledArchFixture, CompareSavedAndFixtureScaledArchMesh)
         _out_ArchMeshUsedForRegressionTest->GetNumberOfCells(),
         _SavedArchCells.size());
 
-    for (size_t point = 0; point < _SavedArchPoints.size(); ++point) {
+    for (std::size_t point = 0; point < _SavedArchPoints.size(); ++point) {
 
         volcart::testing::SmallOrClose(
             _out_ArchMeshUsedForRegressionTest->GetPoint(point)[0],
@@ -644,7 +646,7 @@ TEST_F(ScaledSphereFixture, CompareSavedAndFixtureScaledSphereMesh)
         _out_SphereMeshUsedForRegressionTest->GetNumberOfCells(),
         _SavedSphereCells.size());
 
-    for (size_t point = 0; point < _SavedSpherePoints.size(); ++point) {
+    for (std::size_t point = 0; point < _SavedSpherePoints.size(); ++point) {
 
         volcart::testing::SmallOrClose(
             _out_SphereMeshUsedForRegressionTest->GetPoint(point)[0],
@@ -725,7 +727,7 @@ TEST_F(ScaledConeFixture, CompareSavedAndFixtureScaledConeMesh)
         _out_ConeMeshUsedForRegressionTest->GetNumberOfCells(),
         _SavedConeCells.size());
 
-    for (size_t point = 0; point < _SavedConePoints.size(); ++point) {
+    for (std::size_t point = 0; point < _SavedConePoints.size(); ++point) {
 
         volcart::testing::SmallOrClose(
             _out_ConeMeshUsedForRegressionTest->GetPoint(point)[0],

--- a/meshing/test/SmoothNormalsTest.cpp
+++ b/meshing/test/SmoothNormalsTest.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cstddef>
+
 #include "vc/core/shapes/Arch.hpp"
 #include "vc/core/shapes/Cone.hpp"
 #include "vc/core/shapes/Cube.hpp"
@@ -106,8 +108,8 @@ TEST_F(SmoothNormalsFixture, CompareFixtureSmoothedPlaneWithSavedPlaneTest)
         _out_SmoothedPlaneMesh->GetNumberOfCells(), _SavedPlaneCells.size());
 
     // points
-    for (size_t p_id = 0; p_id < _out_SmoothedPlaneMesh->GetNumberOfPoints();
-         ++p_id) {
+    for (std::size_t p_id = 0;
+         p_id < _out_SmoothedPlaneMesh->GetNumberOfPoints(); ++p_id) {
         volcart::testing::SmallOrClose(
             _out_SmoothedPlaneMesh->GetPoint(p_id)[0],
             _SavedPlanePoints[p_id].x);
@@ -182,8 +184,8 @@ TEST_F(SmoothNormalsFixture, CompareFixtureSmoothedCubeWithSavedCubeTest)
         _out_SmoothedCubeMesh->GetNumberOfCells(), _SavedCubeCells.size());
 
     // points
-    for (size_t p_id = 0; p_id < _out_SmoothedCubeMesh->GetNumberOfPoints();
-         ++p_id) {
+    for (std::size_t p_id = 0;
+         p_id < _out_SmoothedCubeMesh->GetNumberOfPoints(); ++p_id) {
         volcart::testing::SmallOrClose(
             _out_SmoothedCubeMesh->GetPoint(p_id)[0], _SavedCubePoints[p_id].x);
         volcart::testing::SmallOrClose(
@@ -256,8 +258,8 @@ TEST_F(SmoothNormalsFixture, CompareFixtureSmoothedSphereWithSavedSphereTest)
         _out_SmoothedSphereMesh->GetNumberOfCells(), _SavedSphereCells.size());
 
     // points
-    for (size_t p_id = 0; p_id < _out_SmoothedSphereMesh->GetNumberOfPoints();
-         ++p_id) {
+    for (std::size_t p_id = 0;
+         p_id < _out_SmoothedSphereMesh->GetNumberOfPoints(); ++p_id) {
         volcart::testing::SmallOrClose(
             _out_SmoothedSphereMesh->GetPoint(p_id)[0],
             _SavedSpherePoints[p_id].x);
@@ -331,8 +333,8 @@ TEST_F(SmoothNormalsFixture, CompareFixtureSmoothedArchWithSavedArchTest)
         _out_SmoothedArchMesh->GetNumberOfCells(), _SavedArchCells.size());
 
     // points
-    for (size_t p_id = 0; p_id < _out_SmoothedArchMesh->GetNumberOfPoints();
-         ++p_id) {
+    for (std::size_t p_id = 0;
+         p_id < _out_SmoothedArchMesh->GetNumberOfPoints(); ++p_id) {
         volcart::testing::SmallOrClose(
             _out_SmoothedArchMesh->GetPoint(p_id)[0], _SavedArchPoints[p_id].x);
         volcart::testing::SmallOrClose(
@@ -400,8 +402,8 @@ TEST_F(SmoothNormalsFixture, CompareFixtureSmoothedConeWithSavedConeTest)
         _out_SmoothedConeMesh->GetNumberOfPoints(), _SavedConePoints.size());
 
     // points
-    for (size_t p_id = 0; p_id < _out_SmoothedConeMesh->GetNumberOfPoints();
-         ++p_id) {
+    for (std::size_t p_id = 0;
+         p_id < _out_SmoothedConeMesh->GetNumberOfPoints(); ++p_id) {
         volcart::testing::SmallOrClose(
             _out_SmoothedConeMesh->GetPoint(p_id)[0], _SavedConePoints[p_id].x);
         volcart::testing::SmallOrClose(
@@ -487,7 +489,8 @@ TEST_F(SmoothNormalsFixture, SmoothWithZeroRadiusTest)
         ZeroRadiusSmoothedMesh->GetNumberOfCells());
 
     // compare point values
-    for (size_t p_id = 0; p_id < _in_ArchMesh->GetNumberOfPoints(); ++p_id) {
+    for (std::size_t p_id = 0; p_id < _in_ArchMesh->GetNumberOfPoints();
+         ++p_id) {
         volcart::testing::SmallOrClose(
             _in_ArchMesh->GetPoint(p_id)[0],
             ZeroRadiusSmoothedMesh->GetPoint(p_id)[0]);

--- a/python/include/vc/python/PyCVMatCaster.hpp
+++ b/python/include/vc/python/PyCVMatCaster.hpp
@@ -2,6 +2,9 @@
 
 /** @file */
 
+#include <cstddef>
+#include <cstdint>
+
 #include <opencv2/core.hpp>
 #include <pybind11/numpy.h>
 
@@ -21,26 +24,26 @@ public:
 
     static handle cast(cv::Mat src, return_value_policy, handle)
     {
-        size_t size;
+        std::size_t size;
         std::string format;
         auto dims = src.dims;
 
         switch (src.type()) {
             case CV_8U:
-                size = sizeof(uint8_t);
-                format = format_descriptor<uint8_t>::format();
+                size = sizeof(std::uint8_t);
+                format = format_descriptor<std::uint8_t>::format();
                 break;
             case CV_8S:
-                size = sizeof(int8_t);
-                format = format_descriptor<int8_t>::format();
+                size = sizeof(std::int8_t);
+                format = format_descriptor<std::int8_t>::format();
                 break;
             case CV_16U:
-                size = sizeof(uint16_t);
-                format = format_descriptor<uint16_t>::format();
+                size = sizeof(std::uint16_t);
+                format = format_descriptor<std::uint16_t>::format();
                 break;
             case CV_16S:
-                size = sizeof(int16_t);
-                format = format_descriptor<int16_t>::format();
+                size = sizeof(std::int16_t);
+                format = format_descriptor<std::int16_t>::format();
                 break;
             case CV_32F:
                 size = sizeof(float);
@@ -50,8 +53,8 @@ public:
                 throw std::runtime_error("unsupported image type");
         }
 
-        std::vector<size_t> extents;
-        std::vector<size_t> strides;
+        std::vector<std::size_t> extents;
+        std::vector<std::size_t> strides;
 
         if (dims == 2) {
             extents = {
@@ -70,8 +73,8 @@ public:
         }
 
         return array(buffer_info{
-                         src.data, static_cast<ssize_t>(size), format, dims,
-                         extents, strides})
+                         src.data, static_cast<std::ssize_t>(size), format,
+                         dims, extents, strides})
             .release();
     }
 };

--- a/segmentation/include/vc/segmentation/ChainSegmentationAlgorithm.hpp
+++ b/segmentation/include/vc/segmentation/ChainSegmentationAlgorithm.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 #include "vc/core/types/BoundingBox.hpp"
 #include "vc/core/types/Mixins.hpp"
 #include "vc/core/types/OrderedPointSet.hpp"
@@ -59,7 +61,7 @@ public:
      * Typically, the expected number of output iterations. Derived algorithms
      * may produce intermediate iterations that are not included in the output.
      */
-    void setNumberOfSteps(size_t n) { numSteps_ = n; }
+    void setNumberOfSteps(std::size_t n) { numSteps_ = n; }
 
     /** @brief Set the propagation step size
      *
@@ -89,7 +91,10 @@ public:
     /**@}*/
 
     /** @brief Returns the maximum progress value */
-    auto progressIterations() const -> size_t override { return numSteps_; }
+    auto progressIterations() const -> std::size_t override
+    {
+        return numSteps_;
+    }
 
 protected:
     /** Default constructor */
@@ -101,7 +106,7 @@ protected:
     /** Bounding box */
     Bounds bb_;
     /** Number of propagation steps */
-    size_t numSteps_{0};
+    std::size_t numSteps_{0};
     /** Propagation step size */
     double stepSize_{1.0};
     /** Result */

--- a/segmentation/include/vc/segmentation/ComputeVolumetricMask.hpp
+++ b/segmentation/include/vc/segmentation/ComputeVolumetricMask.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+#include <cstdint>
 #include <limits>
 
 #include "vc/core/types/Mixins.hpp"
@@ -33,10 +35,10 @@ public:
     void setVolume(const Volume::Pointer& v);
 
     /** @brief Set the low threshold for the bounded flood-fill operation. */
-    void setLowThreshold(uint16_t t);
+    void setLowThreshold(std::uint16_t t);
 
     /** @brief Set the high threshold for the bounded flood-fill operation. */
-    void setHighThreshold(uint16_t t);
+    void setHighThreshold(std::uint16_t t);
 
     /** @brief If enabled, apply a morphological closing kernel to the mask */
     void setEnableClosing(bool b);
@@ -58,7 +60,7 @@ public:
      * @brief Set the max radius that a single point can hav when measuring the
      * width of the page.
      */
-    void setMaxRadius(size_t radius);
+    void setMaxRadius(std::size_t radius);
 
     /** @brief Computes the segmentation. */
     VolumetricMask::Pointer compute();
@@ -67,7 +69,7 @@ public:
     VolumetricMask::Pointer getMask() const;
 
     /** @brief Returns the maximum progress value */
-    size_t progressIterations() const override;
+    std::size_t progressIterations() const override;
 
 private:
     /** Input points */
@@ -75,9 +77,9 @@ private:
     /** Input volume */
     Volume::Pointer vol_;
     /** Low flood-fill threshold parameter */
-    uint16_t low_{14135};
+    std::uint16_t low_{14135};
     /** High flood-fill threshold parameter */
-    uint16_t high_{65535};
+    std::uint16_t high_{65535};
     /** Enable closing */
     bool enableClosing_{true};
     /** (Square) Kernel size parameter for the closing operation */
@@ -85,7 +87,7 @@ private:
     /** Direction of thickness estimation measurement */
     bool measureVertically_{false};
     /** Maximum layer thickness to consider for a single seed point */
-    size_t maxRadius_{std::numeric_limits<size_t>::max()};
+    std::size_t maxRadius_{std::numeric_limits<std::size_t>::max()};
     /** Mask */
     VolumetricMask::Pointer mask_;
 };

--- a/segmentation/include/vc/segmentation/LocalResliceParticleSim.hpp
+++ b/segmentation/include/vc/segmentation/LocalResliceParticleSim.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstddef>
 #include <iostream>
 
 #include "vc/core/types/OrderedPointSet.hpp"
@@ -113,7 +114,7 @@ public:
     void setDumpVis(bool b) { dumpVis_ = b; }
 
     /** @brief Returns the maximum progress value */
-    [[nodiscard]] auto progressIterations() const -> size_t override;
+    [[nodiscard]] auto progressIterations() const -> std::size_t override;
 
 private:
     /**

--- a/segmentation/include/vc/segmentation/OpticalFlowSegmentation.hpp
+++ b/segmentation/include/vc/segmentation/OpticalFlowSegmentation.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+#include <cstdint>
 #include <optional>
 
 #include "vc/core/types/OrderedPointSet.hpp"
@@ -99,7 +101,7 @@ public:
     auto compute() -> PointSet override;
 
     /** @brief Returns the maximum progress value */
-    [[nodiscard]] auto progressIterations() const -> size_t override;
+    [[nodiscard]] auto progressIterations() const -> std::size_t override;
 
 private:
     /**

--- a/segmentation/include/vc/segmentation/RegionGrowingSegmentationAlgorithmBaseClass.hpp
+++ b/segmentation/include/vc/segmentation/RegionGrowingSegmentationAlgorithmBaseClass.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 #include "vc/core/types/Mixins.hpp"
 #include "vc/core/types/PointSet.hpp"
 #include "vc/core/types/Volume.hpp"
@@ -44,7 +46,7 @@ public:
     void setSeedPoints(SeedPoints p) { startingPoints_ = std::move(p); }
 
     /** @brief Set the number of iterations */
-    void setIterations(size_t i) { iterations_ = i; }
+    void setIterations(std::size_t i) { iterations_ = i; }
 
     /** @brief Compute the segmentation */
     virtual PointSet compute() = 0;
@@ -59,7 +61,7 @@ public:
     PointSet& getPointSet() { return result_; }
 
     /** @brief Returns the maximum progress value */
-    size_t progressIterations() const override { return iterations_; }
+    std::size_t progressIterations() const override { return iterations_; }
 
 protected:
     /** Default constructor */
@@ -71,7 +73,7 @@ protected:
     SeedPoints startingPoints_;
     /** Result */
     PointSet result_;
-    size_t iterations_{0};
+    std::size_t iterations_{0};
     /** Computation status */
     Status status_{Status::Success};
 };

--- a/segmentation/include/vc/segmentation/StructureTensorParticleSim.hpp
+++ b/segmentation/include/vc/segmentation/StructureTensorParticleSim.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 #include <opencv2/core.hpp>
 
 #include "vc/segmentation/ChainSegmentationAlgorithm.hpp"
@@ -56,7 +58,7 @@ public:
     /**@}*/
 
     /** Sends when the segmentation is updated with intermediate results */
-    size_t progressIterations() const override;
+    std::size_t progressIterations() const override;
 
 private:
     /** Scale factor for propagation force */

--- a/segmentation/include/vc/segmentation/ThinnedFloodFillSegmentation.hpp
+++ b/segmentation/include/vc/segmentation/ThinnedFloodFillSegmentation.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+#include <cstdint>
 #include <limits>
 
 #include "vc/core/types/PointSet.hpp"
@@ -62,10 +64,10 @@ public:
         default;
 
     /** @brief Set the low threshold for the bounded flood-fill operation. */
-    void setFFLowThreshold(uint16_t t);
+    void setFFLowThreshold(std::uint16_t t);
 
     /** @brief Set the high threshold for the bounded flood-fill operation. */
-    void setFFHighThreshold(uint16_t t);
+    void setFFHighThreshold(std::uint16_t t);
 
     /**
      * @brief Set the threshold for the distance transform pre-processing
@@ -93,7 +95,7 @@ public:
      * @brief Set the max radius that a single point can hav when measuring the
      * width of the page.
      */
-    void setMaxRadius(size_t radius);
+    void setMaxRadius(std::size_t radius);
 
     /** @brief Computes the segmentation. */
     PointSet compute() override;
@@ -112,9 +114,9 @@ public:
 
 private:
     /** Low flood-fill threshold parameter */
-    uint16_t low_{14135};
+    std::uint16_t low_{14135};
     /** High flood-fill threshold parameter */
-    uint16_t high_{65535};
+    std::uint16_t high_{65535};
     /** Distance transform threshold parameter */
     float dtt_{0};
     /** (Square) Kernel size parameter for the closing operation */
@@ -122,14 +124,14 @@ private:
     /** Dump visualization to disk flag */
     bool dumpVis_{false};
     /** Prune spurs of this length or shorter */
-    size_t spurLength_{6};
+    std::size_t spurLength_{6};
     /**
      * Indicate which direction thickness should be measured in.
      * Horizontal by default
      */
     bool measureVertically_{false};
     /** Maximum layer thickness to consider for a single seed point */
-    size_t maxRadius_{std::numeric_limits<size_t>::max()};
+    std::size_t maxRadius_{std::numeric_limits<std::size_t>::max()};
     /** Mask */
     VoxelMask volMask_;
 };

--- a/segmentation/include/vc/segmentation/lrps/Derivative.hpp
+++ b/segmentation/include/vc/segmentation/lrps/Derivative.hpp
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <cassert>
+#include <cstddef>
 #include <vector>
 
 namespace volcart::segmentation
@@ -53,7 +54,7 @@ T D1Forward(const std::vector<T>& vs, int index, int hstep = 1)
 {
     assert(index >= 0 && index < int(vs.size()) && "index not in range of vs");
     assert(index <= int(vs.size()) && "index must not be last point");
-    return (-vs[index] + vs[size_t(index) + hstep]) / double(hstep);
+    return (-vs[index] + vs[std::size_t(index) + hstep]) / double(hstep);
 }
 
 /**
@@ -90,7 +91,8 @@ T D1Central(const std::vector<T>& vs, int index, int hstep = 1)
     assert(index >= 0 && index < int(vs.size()) && "index not in range of vs");
     assert(index - hstep >= 0 && "index out of range");
     assert(index + hstep < int(vs.size()) && "index out of range");
-    return ((-0.5) * vs[index - hstep] + (0.5) * vs[size_t(index) + hstep]) /
+    return ((-0.5) * vs[index - hstep] +
+            (0.5) * vs[std::size_t(index) + hstep]) /
            double(hstep);
 }
 
@@ -118,8 +120,8 @@ T D1FivePointStencil(const std::vector<T>& vs, int index, int hstep = 1)
     return (
         (1.0/12) * vs[index - 2 * hstep] +
         (-2.0/3) * vs[index - hstep] +
-         (2.0/3) * vs[size_t(index) + hstep] +
-       (-1.0/12) * vs[size_t(index) + 2 * hstep]) /
+         (2.0/3) * vs[std::size_t(index) + hstep] +
+       (-1.0/12) * vs[std::size_t(index) + 2 * hstep]) /
            double(hstep);
     // clang-format on
 }
@@ -163,7 +165,7 @@ std::vector<T> D1(const std::vector<T>& vs, int hstep = 1)
 {
     std::vector<T> dvs;
     dvs.reserve(vs.size());
-    for (size_t i = 0; i < vs.size(); ++i) {
+    for (std::size_t i = 0; i < vs.size(); ++i) {
         dvs.push_back(D1At(vs, i, hstep));
     }
     return dvs;
@@ -181,8 +183,8 @@ T D2Forward(const std::vector<T>& vs, int index, int hstep = 1)
     assert(index >= 0 && index < int(vs.size()) && "index out of range");
     assert(index + hstep < int(vs.size()) && "index out of range");
     assert(index + 2 * hstep < int(vs.size()) && "index out of  range");
-    return (vs[index] + (-2.0) * vs[size_t(index) + hstep] +
-            vs[size_t(index) + 2 * hstep]) /
+    return (vs[index] + (-2.0) * vs[std::size_t(index) + hstep] +
+            vs[std::size_t(index) + 2 * hstep]) /
            double(hstep * hstep);
 }
 
@@ -215,7 +217,7 @@ T D2Central(const std::vector<T>& vs, int index, int hstep = 1)
     assert(index - hstep >= 0 && "index out of range");
     assert(index + hstep < int(vs.size()) && "index out of range");
     return (vs[index - hstep] + (-2.0) * vs[index] +
-            vs[size_t(index) + hstep]) /
+            vs[std::size_t(index) + hstep]) /
            double(hstep * hstep);
 }
 
@@ -240,8 +242,8 @@ T D2FivePointStencil(const std::vector<T>& vs, int index, int hstep = 1)
        (-1.0/12) * vs[index - 2 * hstep] +
          (4.0/3) * vs[index - hstep] +
         (-5.0/2) * vs[index] +
-         (4.0/3) * vs[size_t(index) + hstep] +
-       (-1.0/12) * vs[size_t(index) + 2 * hstep]) /
+         (4.0/3) * vs[std::size_t(index) + hstep] +
+       (-1.0/12) * vs[std::size_t(index) + 2 * hstep]) /
            double(hstep * hstep);
     // clang-format on
 }
@@ -282,7 +284,7 @@ std::vector<T> D2(const std::vector<T>& vs, int hstep = 1)
 {
     std::vector<T> dvs;
     dvs.reserve(vs.size());
-    for (size_t i = 0; i < vs.size(); ++i) {
+    for (std::size_t i = 0; i < vs.size(); ++i) {
         dvs.push_back(D2At(vs, i, hstep));
     }
     return dvs;

--- a/segmentation/include/vc/segmentation/lrps/FittedCurve.hpp
+++ b/segmentation/include/vc/segmentation/lrps/FittedCurve.hpp
@@ -3,7 +3,9 @@
 /** @file */
 
 #include <cassert>
+#include <cstddef>
 #include <vector>
+
 #include "vc/segmentation/lrps/Common.hpp"
 #include "vc/segmentation/lrps/Spline.hpp"
 
@@ -18,7 +20,7 @@ class FittedCurve
 {
 private:
     /** Number of points in the curve*/
-    size_t npoints_{0};
+    std::size_t npoints_{0};
     /** z-position of the curve */
     int zIndex_{0};
     /** Parameterized nodes */
@@ -45,7 +47,7 @@ public:
     /**@}*/
 
     /** @brief Return the current number of resampled points in the spline */
-    size_t size() const { return npoints_; }
+    std::size_t size() const { return npoints_; }
 
     /** @brief Return the current list of resampled points */
     const std::vector<Voxel>& points() const { return points_; }
@@ -67,7 +69,7 @@ public:
     std::vector<Voxel> resample(double resamplePerc = 1.0);
 
     /** @brief Resample the curve to have numPoints of evenly spaced points */
-    std::vector<Voxel> sample(size_t numPoints) const;
+    std::vector<Voxel> sample(std::size_t numPoints) const;
 
     /** @brief Returns the voxel located at index */
     Voxel operator()(int index) const;

--- a/segmentation/include/vc/segmentation/lrps/IntensityMap.hpp
+++ b/segmentation/include/vc/segmentation/lrps/IntensityMap.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstdint>
 #include <deque>
 #include <iostream>
 #include <utility>
@@ -77,7 +78,7 @@ private:
     cv::Mat_<double> intensities_;
 
     /** Input matrix */
-    cv::Mat_<uint8_t> resliceData_;
+    cv::Mat_<std::uint8_t> resliceData_;
 
     /** Width of the image returned by draw() */
     int displayWidth_;

--- a/segmentation/include/vc/segmentation/lrps/Spline.hpp
+++ b/segmentation/include/vc/segmentation/lrps/Spline.hpp
@@ -3,6 +3,7 @@
 /** @file */
 
 #include <cassert>
+#include <cstddef>
 #include <vector>
 
 #include <unsupported/Eigen/Splines>
@@ -51,7 +52,7 @@ public:
 
 private:
     /** Number of points on the spline */
-    size_t npoints_;
+    std::size_t npoints_;
 
     SplineType spline_;
 

--- a/segmentation/include/vc/segmentation/stps/ForceChain.hpp
+++ b/segmentation/include/vc/segmentation/stps/ForceChain.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstddef>
 #include <vector>
 
 #include <opencv2/core.hpp>
@@ -44,10 +45,10 @@ public:
     ForceChain& operator*=(const double& rhs);
 
     /** @brief Element access operator */
-    auto operator[](size_t i) { return data_[i]; }
+    auto operator[](std::size_t i) { return data_[i]; }
 
-    /** @copydoc operator[](size_t) */
-    auto operator[](size_t i) const { return data_[i]; }
+    /** @copydoc operator[](std::size_t) */
+    auto operator[](std::size_t i) const { return data_[i]; }
 
     /** @brief Returns an iterator to the beginning of the chain */
     auto begin() { return data_.begin(); }
@@ -72,10 +73,10 @@ public:
     void push_back(const Force& val) { data_.push_back(val); }
 
     /** @brief Returns the number of elements in the chain */
-    size_t size() { return data_.size(); }
+    std::size_t size() { return data_.size(); }
 
     /** @copydoc size() */
-    size_t size() const { return data_.size(); }
+    std::size_t size() const { return data_.size(); }
 
     /** @brief Empties and resets the chain */
     void clear() { data_.clear(); }

--- a/segmentation/include/vc/segmentation/stps/ParticleChain.hpp
+++ b/segmentation/include/vc/segmentation/stps/ParticleChain.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstddef>
 #include <vector>
 
 #include <opencv2/core.hpp>
@@ -43,10 +44,10 @@ public:
     ParticleChain& operator*=(const double& rhs);
 
     /** @brief Element access operator */
-    auto operator[](size_t i) { return data_[i]; }
+    auto operator[](std::size_t i) { return data_[i]; }
 
-    /** @copydoc operator[](size_t) */
-    auto operator[](size_t i) const { return data_[i]; }
+    /** @copydoc operator[](std::size_t) */
+    auto operator[](std::size_t i) const { return data_[i]; }
 
     /** @brief Returns an iterator to the beginning of the chain */
     auto begin() { return data_.begin(); }
@@ -71,10 +72,10 @@ public:
     void push_back(const Particle& val) { data_.push_back(val); }
 
     /** @brief Returns the number of elements in the chain */
-    size_t size() { return data_.size(); }
+    std::size_t size() { return data_.size(); }
 
     /** @copydoc size() */
-    size_t size() const { return data_.size(); }
+    std::size_t size() const { return data_.size(); }
 
     /** @brief Empties and resets the chain */
     void clear() { data_.clear(); }

--- a/segmentation/include/vc/segmentation/tff/FloodFill.hpp
+++ b/segmentation/include/vc/segmentation/tff/FloodFill.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include <opencv2/core.hpp>
@@ -24,13 +26,13 @@ int EuclideanDistance(const cv::Vec3i& start, const cv::Vec3i& end);
  * `[low, high]` or until `maxRadius` is reached. If `measureVert` is true,
  * projects vertically from seed. Otherwise, projects horizontally.
  */
-size_t MeasureThickness(
+std::size_t MeasureThickness(
     const cv::Vec3i& seed,
     const cv::Mat& slice,
-    uint16_t low,
-    uint16_t high,
+    std::uint16_t low,
+    std::uint16_t high,
     bool measureVert,
-    size_t maxRadius);
+    std::size_t maxRadius);
 
 /** Find the median element in a container */
 template <class Container>
@@ -50,7 +52,7 @@ std::vector<cv::Vec3i> DoFloodFill(
     const std::vector<cv::Vec3i>& pts,
     int bound,
     cv::Mat img,
-    uint16_t low,
-    uint16_t high);
+    std::uint16_t low,
+    std::uint16_t high);
 
 }  // namespace volcart::segmentation

--- a/segmentation/src/Common.cpp
+++ b/segmentation/src/Common.cpp
@@ -1,5 +1,7 @@
 #include "vc/segmentation/lrps/Common.hpp"
 
+#include <cstddef>
+
 std::vector<double> volcart::segmentation::SquareDiff(
     const std::vector<Voxel>& v1, const std::vector<Voxel>& v2)
 {
@@ -17,7 +19,7 @@ double volcart::segmentation::SumSquareDiff(
 {
     assert(v1.size() == v2.size() && "v1 and v2 must be the same size");
     double res = 0;
-    for (size_t i = 0; i < v1.size(); ++i) {
+    for (std::size_t i = 0; i < v1.size(); ++i) {
         res += (v1[i] - v2[i]) * (v1[i] - v2[i]);
     }
     return std::sqrt(res);

--- a/segmentation/src/ComputeVolumetricMask.cpp
+++ b/segmentation/src/ComputeVolumetricMask.cpp
@@ -12,9 +12,9 @@ using namespace volcart::segmentation;
 using Voxel = cv::Vec3i;
 using VoxelList = std::vector<Voxel>;
 
-void ComputeVolumetricMask::setLowThreshold(uint16_t t) { low_ = t; }
+void ComputeVolumetricMask::setLowThreshold(std::uint16_t t) { low_ = t; }
 
-void ComputeVolumetricMask::setHighThreshold(uint16_t t) { high_ = t; }
+void ComputeVolumetricMask::setHighThreshold(std::uint16_t t) { high_ = t; }
 
 void ComputeVolumetricMask::setEnableClosing(bool b) { enableClosing_ = b; }
 
@@ -25,7 +25,10 @@ void ComputeVolumetricMask::setMeasureVertical(bool b)
     measureVertically_ = b;
 }
 
-void ComputeVolumetricMask::setMaxRadius(size_t radius) { maxRadius_ = radius; }
+void ComputeVolumetricMask::setMaxRadius(std::size_t radius)
+{
+    maxRadius_ = radius;
+}
 
 VolumetricMask::Pointer ComputeVolumetricMask::compute()
 {
@@ -34,11 +37,11 @@ VolumetricMask::Pointer ComputeVolumetricMask::compute()
 
     // Initialize running points with the provided starting seeds
     // Converts double-to-int by truncation
-    auto startSlice = std::numeric_limits<size_t>::max();
-    size_t endSlice{0};
-    std::map<size_t, VoxelList> seedsBySlice;
+    auto startSlice = std::numeric_limits<std::size_t>::max();
+    std::size_t endSlice{0};
+    std::map<std::size_t, VoxelList> seedsBySlice;
     for (const auto& pt : input_) {
-        auto sliceIdx = static_cast<size_t>(pt[2]);
+        auto sliceIdx = static_cast<std::size_t>(pt[2]);
         startSlice = std::min(startSlice, sliceIdx);
         endSlice = std::max(endSlice, sliceIdx);
         seedsBySlice[sliceIdx].emplace_back(pt[0], pt[1], pt[2]);
@@ -65,7 +68,7 @@ VolumetricMask::Pointer ComputeVolumetricMask::compute()
         auto slice = vol_->getSliceDataCopy(zIndex);
 
         // Estimate thickness of page from every seed point.
-        std::vector<size_t> estimates;
+        std::vector<std::size_t> estimates;
         for (const auto& v : seedPoints) {
             estimates.emplace_back(MeasureThickness(
                 v, slice, low_, high_, measureVertically_, maxRadius_));
@@ -84,7 +87,7 @@ VolumetricMask::Pointer ComputeVolumetricMask::compute()
             // Convert mask to a binary image so we can apply closing
             cv::Mat binaryImg = cv::Mat::zeros(slice.size(), CV_8UC1);
             for (const Voxel& v : sliceMask) {
-                binaryImg.at<uint8_t>(v[1], v[0]) = 255;
+                binaryImg.at<std::uint8_t>(v[1], v[0]) = 255;
             }
 
             cv::Mat kernel = cv::Mat::ones(kernel_, kernel_, CV_8U);
@@ -95,7 +98,7 @@ VolumetricMask::Pointer ComputeVolumetricMask::compute()
             for (const auto p : range2D(closedImg.rows, closedImg.cols)) {
                 const auto& x = p.second;
                 const auto& y = p.first;
-                if (closedImg.at<uint8_t>(y, x) > 0) {
+                if (closedImg.at<std::uint8_t>(y, x) > 0) {
                     mask_->setIn({x, y, zIndex});
                 }
             }
@@ -113,7 +116,7 @@ void ComputeVolumetricMask::setVolume(const Volume::Pointer& v) { vol_ = v; }
 
 VolumetricMask::Pointer ComputeVolumetricMask::getMask() const { return mask_; }
 
-size_t ComputeVolumetricMask::progressIterations() const
+std::size_t ComputeVolumetricMask::progressIterations() const
 {
     if (input_.empty()) {
         return 0;
@@ -121,7 +124,7 @@ size_t ComputeVolumetricMask::progressIterations() const
     auto minmax = std::minmax_element(
         input_.begin(), input_.end(),
         [](const auto& a, const auto& b) { return a[2] < b[2]; });
-    auto startSlice = static_cast<size_t>((*minmax.first)[2]);
-    auto endSlice = static_cast<size_t>((*minmax.second)[2]);
+    auto startSlice = static_cast<std::size_t>((*minmax.first)[2]);
+    auto endSlice = static_cast<std::size_t>((*minmax.second)[2]);
     return endSlice + 1 - startSlice;
 }

--- a/segmentation/src/EnergyMetrics.cpp
+++ b/segmentation/src/EnergyMetrics.cpp
@@ -1,7 +1,9 @@
+#include "vc/segmentation/lrps/EnergyMetrics.hpp"
+
+#include <cstddef>
 #include <iostream>
 
 #include "vc/segmentation/lrps/Derivative.hpp"
-#include "vc/segmentation/lrps/EnergyMetrics.hpp"
 
 using namespace volcart::segmentation;
 
@@ -108,7 +110,7 @@ double EnergyMetrics::WindowedArcLength(
     }
 
     double sum = 0;
-    for (size_t i = 0; i < curve.size(); ++i) {
+    for (std::size_t i = 0; i < curve.size(); ++i) {
         sum += EnergyMetrics::LocalWindowedArcLength(curve, i, windowSize);
     }
     return sum / curve.size();

--- a/segmentation/src/FittedCurve.cpp
+++ b/segmentation/src/FittedCurve.cpp
@@ -7,7 +7,7 @@
 
 using namespace volcart::segmentation;
 
-std::vector<double> GenerateTVals(size_t count);
+std::vector<double> GenerateTVals(std::size_t count);
 
 FittedCurve::FittedCurve(const std::vector<Voxel>& vs, int zIndex)
     : npoints_(vs.size()), zIndex_(zIndex), ts_(GenerateTVals(npoints_))
@@ -27,7 +27,7 @@ FittedCurve::FittedCurve(const std::vector<Voxel>& vs, int zIndex)
 
 std::vector<Voxel> FittedCurve::resample(double resamplePerc)
 {
-    npoints_ = size_t(std::round(resamplePerc * npoints_));
+    npoints_ = std::size_t(std::round(resamplePerc * npoints_));
 
     // If we're resampling at 100%, re-use last tvals
     if (resamplePerc != 1.0) {
@@ -39,7 +39,7 @@ std::vector<Voxel> FittedCurve::resample(double resamplePerc)
     return points_;
 }
 
-std::vector<Voxel> FittedCurve::sample(size_t numPoints) const
+std::vector<Voxel> FittedCurve::sample(std::size_t numPoints) const
 {
     std::vector<Voxel> newPoints(numPoints);
     newPoints.reserve(numPoints);
@@ -73,7 +73,7 @@ std::vector<double> FittedCurve::curvature(int hstep) const
     // according to: http://mathworld.wolfram.com/Curvature.html
     std::vector<double> k;
     k.reserve(points_.size());
-    for (size_t i = 0; i < points_.size(); ++i) {
+    for (std::size_t i = 0; i < points_.size(); ++i) {
         k.push_back(
             (dx1[i] * dy2[i] - dy1[i] * dx2[i]) /
             std::pow(dx1[i] * dx1[i] + dy1[i] * dy1[i], 3.0 / 2.0));
@@ -85,13 +85,13 @@ std::vector<double> FittedCurve::curvature(int hstep) const
 double FittedCurve::arclength() const
 {
     double length = 0;
-    for (size_t i = 1; i < npoints_; ++i) {
+    for (std::size_t i = 1; i < npoints_; ++i) {
         length += cv::norm(points_[i], points_[i - 1]);
     }
     return length;
 }
 
-std::vector<double> GenerateTVals(size_t count)
+std::vector<double> GenerateTVals(std::size_t count)
 {
     std::vector<double> ts(count);
     if (count > 0) {

--- a/segmentation/src/FloodFill.cpp
+++ b/segmentation/src/FloodFill.cpp
@@ -33,13 +33,13 @@ int vcs::EuclideanDistance(const cv::Vec3i& start, const cv::Vec3i& end)
     return static_cast<int>(cv::norm(end - start));
 }
 
-size_t vcs::MeasureThickness(
+std::size_t vcs::MeasureThickness(
     const cv::Vec3i& seed,
     const cv::Mat& slice,
-    uint16_t low,
-    uint16_t high,
+    std::uint16_t low,
+    std::uint16_t high,
     bool measureVert,
-    size_t maxRadius)
+    std::size_t maxRadius)
 {
     int xPos{seed[0]};
     int xNeg{seed[0]};
@@ -47,7 +47,7 @@ size_t vcs::MeasureThickness(
     int yNeg{seed[1]};
     bool foundMin{false};
     bool foundMax{false};
-    size_t length{1};
+    std::size_t length{1};
 
     while (!foundMin || !foundMax) {
         if (measureVert) {
@@ -64,7 +64,7 @@ size_t vcs::MeasureThickness(
 
         // Check the negative direction
         if (!foundMin) {
-            auto val = slice.at<uint16_t>(yNeg, xNeg);
+            auto val = slice.at<std::uint16_t>(yNeg, xNeg);
             if (val < low or val > high) {
                 foundMin = true;
             }
@@ -72,7 +72,7 @@ size_t vcs::MeasureThickness(
 
         // Check the positive direction
         if (!foundMax) {
-            auto val = slice.at<uint16_t>(yPos, xPos);
+            auto val = slice.at<std::uint16_t>(yPos, xPos);
             if (val < low or val > high) {
                 foundMax = true;
             }
@@ -91,7 +91,11 @@ size_t vcs::MeasureThickness(
 }
 
 VoxelList vcs::DoFloodFill(
-    const VoxelList& pts, int bound, cv::Mat img, uint16_t low, uint16_t high)
+    const VoxelList& pts,
+    int bound,
+    cv::Mat img,
+    std::uint16_t low,
+    std::uint16_t high)
 {
     std::queue<VoxelPair> q;
     VoxelList mask;
@@ -100,7 +104,7 @@ VoxelList vcs::DoFloodFill(
     // Push all the initial points onto the queue.
     // Initial points are their own 'parents'.
     for (const auto& pt : pts) {
-        auto greyVal = img.at<uint16_t>(pt[1], pt[0]);
+        auto greyVal = img.at<std::uint16_t>(pt[1], pt[0]);
         if (greyVal >= low && greyVal <= high) {
             q.emplace(pt, pt);
             visited.insert(pt);
@@ -133,7 +137,7 @@ VoxelList vcs::DoFloodFill(
             }
 
             // Add the valid neighbor to the queue and mark it as visited.
-            auto val = img.at<uint16_t>(neighbor[1], neighbor[0]);
+            auto val = img.at<std::uint16_t>(neighbor[1], neighbor[0]);
             auto dist = EuclideanDistance(neighbor, pair.parent);
             if (val >= low && val <= high && dist <= bound) {
                 q.emplace(neighbor, pair.parent);

--- a/segmentation/src/IntensityMap.cpp
+++ b/segmentation/src/IntensityMap.cpp
@@ -19,7 +19,7 @@ IntensityMap::IntensityMap(
 {
     assert(r.rows > 2);
     // DEBUG - need to convert to 8 bit before we can do anything
-    r.convertTo(r, CV_8UC1, 1.0 / std::numeric_limits<uint8_t>::max());
+    r.convertTo(r, CV_8UC1, 1.0 / std::numeric_limits<std::uint8_t>::max());
     cv::equalizeHist(r, r);
     resliceData_ = r;
 

--- a/segmentation/src/LocalResliceParticleSim.cpp
+++ b/segmentation/src/LocalResliceParticleSim.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <deque>
 #include <iomanip>
 #include <limits>
@@ -23,13 +24,13 @@ namespace fs = volcart::filesystem;
 using std::begin;
 using std::end;
 
-size_t LocalResliceSegmentation::progressIterations() const
+std::size_t LocalResliceSegmentation::progressIterations() const
 {
     auto minZPoint = std::min_element(
         startingChain_.begin(), startingChain_.end(),
         [](auto a, auto b) { return a[2] < b[2]; });
     auto startIndex = static_cast<int>(std::floor((*minZPoint)[2]));
-    return static_cast<size_t>((endIndex_ - startIndex) / stepSize_);
+    return static_cast<std::size_t>((endIndex_ - startIndex) / stepSize_);
 }
 
 LocalResliceSegmentation::PointSet LocalResliceSegmentation::compute()
@@ -72,12 +73,12 @@ LocalResliceSegmentation::PointSet LocalResliceSegmentation::compute()
     // Collection to hold all positions
     std::vector<std::vector<Voxel>> points;
     points.reserve(
-        (endIndex_ - startIndex + 1) / static_cast<uint64_t>(stepSize_));
+        (endIndex_ - startIndex + 1) / static_cast<std::uint64_t>(stepSize_));
     points.push_back(currentVs);
 
     // Iterate over z-slices
     auto stepSize = static_cast<int>(stepSize_);
-    size_t iteration{0};
+    std::size_t iteration{0};
     for (int zIndex = startIndex; zIndex < endIndex_; zIndex += stepSize) {
         // Update progress
         progressUpdated(iteration++);
@@ -256,7 +257,7 @@ LocalResliceSegmentation::PointSet LocalResliceSegmentation::compute()
         while (*maxVal > 10.0 && settlingIters++ < 100) {
             Voxel newPoint;
             int i = maxVal - begin(normDeriv2);
-            Voxel diff = 0.5 * nextVs[size_t(i) + 1] - 0.5 * nextVs[i - 1];
+            Voxel diff = 0.5 * nextVs[std::size_t(i) + 1] - 0.5 * nextVs[i - 1];
             newPoint = nextVs[i - 1] + diff;
             nextVs[i] = newPoint;
 
@@ -296,13 +297,13 @@ LocalResliceSegmentation::PointSet LocalResliceSegmentation::compute()
         // algorithm will choose.
         if (dumpVis_) {
             // Create output directory for this iter's output
-            const size_t nchars = std::to_string(endIndex_).size();
+            const std::size_t nchars = std::to_string(endIndex_).size();
             std::stringstream iterDirSS;
             iterDirSS << std::setw(nchars) << std::setfill('0') << zIndex;
             fs::create_directory(outputDir / iterDirSS.str());
 
             // Dump chain, map, reslice for every particle
-            for (size_t i = 0; i < nextVs.size(); ++i) {
+            for (std::size_t i = 0; i < nextVs.size(); ++i) {
                 cv::Mat chain =
                     draw_particle_on_slice_(currentCurve, zIndex, i);
                 cv::Mat resliceMat = reslices[i].draw();
@@ -357,8 +358,8 @@ LocalResliceSegmentation::create_final_pointset_(
     result_.clear();
     result_.setWidth(cols);
 
-    for (size_t i = 0; i < rows; ++i) {
-        for (size_t j = 0; j < cols; ++j) {
+    for (std::size_t i = 0; i < rows; ++i) {
+        for (std::size_t j = 0; j < cols; ++j) {
             Voxel v = points[i][j];
             tempRow.emplace_back(v(0), v(1), v(2));
         }
@@ -376,7 +377,7 @@ cv::Mat LocalResliceSegmentation::draw_particle_on_slice_(
 {
     auto pkgSlice = vol_->getSliceDataCopy(sliceIndex);
     pkgSlice.convertTo(
-        pkgSlice, CV_8UC3, 1.0 / std::numeric_limits<uint8_t>::max());
+        pkgSlice, CV_8UC3, 1.0 / std::numeric_limits<std::uint8_t>::max());
     cv::cvtColor(pkgSlice, pkgSlice, cv::COLOR_GRAY2BGR);
 
     // Superimpose interpolated currentCurve on window
@@ -392,7 +393,7 @@ cv::Mat LocalResliceSegmentation::draw_particle_on_slice_(
         cv::polylines(pkgSlice, contour, false, BGR_BLUE, 1, cv::LINE_AA);
     } else {
         // Draw circles on the pkgSlice window for each point
-        for (size_t i = 0; i < curve.size(); ++i) {
+        for (std::size_t i = 0; i < curve.size(); ++i) {
             cv::Point real{int(curve(i)(0)), int(curve(i)(1))};
             cv::circle(pkgSlice, real, 2, BGR_GREEN, -1);
         }

--- a/segmentation/src/OpticalFlowSegmentation.cpp
+++ b/segmentation/src/OpticalFlowSegmentation.cpp
@@ -112,13 +112,13 @@ void OpticalFlowSegmentation::setVisualize(bool b) { visualize_ = b; }
 
 void OpticalFlowSegmentation::setDumpVis(bool b) { dumpVis_ = b; }
 
-auto OpticalFlowSegmentation::progressIterations() const -> size_t
+auto OpticalFlowSegmentation::progressIterations() const -> std::size_t
 {
     auto minZPoint = std::min_element(
         startingChain_.begin(), startingChain_.end(),
         [](const auto& a, const auto& b) { return a[2] < b[2]; });
     auto startIndex = static_cast<int>(std::floor((*minZPoint)[2]));
-    return static_cast<size_t>((endIndex_ - startIndex) / stepSize_);
+    return static_cast<std::size_t>((endIndex_ - startIndex) / stepSize_);
 }
 
 // Multithreaded computation of split curve segment
@@ -440,8 +440,8 @@ auto OpticalFlowSegmentation::create_final_pointset_(
     result_.clear();
     result_.setWidth(cols);
 
-    for (size_t i = 0; i < rows; ++i) {
-        for (size_t j = 0; j < cols; ++j) {
+    for (std::size_t i = 0; i < rows; ++i) {
+        for (std::size_t j = 0; j < cols; ++j) {
             Voxel v = points[i][j];
             tempRow.emplace_back(v(0), v(1), v(2));
         }
@@ -459,7 +459,7 @@ auto OpticalFlowSegmentation::draw_particle_on_slice_(
 {
     auto pkgSlice = vol_->getSliceDataCopy(sliceIndex);
     pkgSlice.convertTo(
-        pkgSlice, CV_8UC3, 1.0 / std::numeric_limits<uint8_t>::max());
+        pkgSlice, CV_8UC3, 1.0 / std::numeric_limits<std::uint8_t>::max());
     cv::cvtColor(pkgSlice, pkgSlice, cv::COLOR_GRAY2BGR);
 
     // Superimpose interpolated currentCurve on window
@@ -475,7 +475,7 @@ auto OpticalFlowSegmentation::draw_particle_on_slice_(
         cv::polylines(pkgSlice, contour, false, color::BLUE, 1, cv::LINE_AA);
     } else {
         // Draw circles on the pkgSlice window for each point
-        for (size_t i = 0; i < curve.size(); ++i) {
+        for (std::size_t i = 0; i < curve.size(); ++i) {
             cv::Point real{int(curve(i)(0)), int(curve(i)(1))};
             cv::circle(pkgSlice, real, 2, color::GREEN, -1);
         }

--- a/segmentation/src/StructureTensorParticleSim.cpp
+++ b/segmentation/src/StructureTensorParticleSim.cpp
@@ -7,9 +7,9 @@ using namespace vc::segmentation;
 
 static constexpr double RK_STEP_SCALE = 1.0 / 6.0;
 
-size_t StructureTensorParticleSim::progressIterations() const
+std::size_t StructureTensorParticleSim::progressIterations() const
 {
-    return static_cast<size_t>(std::ceil(numSteps_ / stepSize_));
+    return static_cast<std::size_t>(std::ceil(numSteps_ / stepSize_));
 }
 
 StructureTensorParticleSim::PointSet StructureTensorParticleSim::compute()
@@ -45,17 +45,17 @@ StructureTensorParticleSim::PointSet StructureTensorParticleSim::compute()
         std::ceil(materialThickness_ / vol_->voxelSize()) * 0.5);
 
     // Output iterations
-    auto outIters = static_cast<size_t>(std::ceil(numSteps_ / stepSize_));
+    auto outIters = static_cast<std::size_t>(std::ceil(numSteps_ / stepSize_));
     // Runge-Kutta iterations
-    auto rkIters = static_cast<size_t>(std::ceil(stepSize_ / rkStepSize_));
+    auto rkIters = static_cast<std::size_t>(std::ceil(stepSize_ / rkStepSize_));
 
     // Sampled output iterations
-    for (size_t it = 0; it < outIters; it++) {
+    for (std::size_t it = 0; it < outIters; it++) {
         // Update progress
         progressUpdated(it);
 
         // Run Runge-Kutta multiple times to accumulate one full output step
-        for (size_t rkIt = 0; rkIt < rkIters; rkIt++) {
+        for (std::size_t rkIt = 0; rkIt < rkIters; rkIt++) {
             // K1
             auto chainK1 = currentChain_;
             auto k1 = calc_prop_forces_(chainK1) + calc_spring_forces_(chainK1);

--- a/segmentation/src/ThinnedFloodFillSegmentation.cpp
+++ b/segmentation/src/ThinnedFloodFillSegmentation.cpp
@@ -50,7 +50,7 @@ static VoxelSet FindIntersections(const VoxelSet& pts)
  * Search the skeleton for spurs.
  * An 'intersection' where more than two paths are available contains a spur.
  * */
-static VoxelSet PruneSpurs(VoxelSet skeleton, size_t spurLength)
+static VoxelSet PruneSpurs(VoxelSet skeleton, std::size_t spurLength)
 {
     auto intersections = FindIntersections(skeleton);
 
@@ -228,13 +228,13 @@ static TFF::PointSet AppendVoxelSetToPointSet(
     return result;
 }
 
-void TFF::setFFLowThreshold(uint16_t t) { low_ = t; }
-void TFF::setFFHighThreshold(uint16_t t) { high_ = t; }
+void TFF::setFFLowThreshold(std::uint16_t t) { low_ = t; }
+void TFF::setFFHighThreshold(std::uint16_t t) { high_ = t; }
 void TFF::setDistanceTransformThreshold(float t) { dtt_ = t; }
 void TFF::setClosingKernelSize(int s) { kernel_ = s; }
 void TFF::setMeasureVertical(bool b) { measureVertically_ = b; }
 void TFF::setSpurLengthThreshold(int length) { spurLength_ = length; }
-void TFF::setMaxRadius(size_t radius) { maxRadius_ = radius; }
+void TFF::setMaxRadius(std::size_t radius) { maxRadius_ = radius; }
 TFF::VoxelMask TFF::getMask() const { return volMask_; }
 void TFF::setDumpVis(bool b) { dumpVis_ = b; }
 
@@ -260,9 +260,9 @@ TFF::PointSet TFF::compute()
     // Initialize running points with the provided starting seeds
     // Converts double-to-int by truncation
     VoxelList seedPoints;
-    auto startSlice = std::numeric_limits<size_t>::max();
+    auto startSlice = std::numeric_limits<std::size_t>::max();
     for (const auto& pt : startingPoints_) {
-        startSlice = std::min(startSlice, static_cast<size_t>(pt[2]));
+        startSlice = std::min(startSlice, static_cast<std::size_t>(pt[2]));
         seedPoints.emplace_back(pt[0], pt[1], pt[2]);
     }
 
@@ -287,7 +287,7 @@ TFF::PointSet TFF::compute()
         auto slice = vol_->getSliceDataCopy(zIndex);
 
         // Estimate thickness of page from every seed point.
-        std::vector<size_t> estimates;
+        std::vector<std::size_t> estimates;
         for (const auto& v : seedPoints) {
             estimates.emplace_back(MeasureThickness(
                 v, slice, low_, high_, measureVertically_, maxRadius_));
@@ -308,7 +308,7 @@ TFF::PointSet TFF::compute()
         // Each voxel in the mask should be assigned 'white' in the binary
         // image.
         for (const Voxel& v : sliceMask) {
-            binaryImg.at<uint8_t>(v[1], v[0]) = 255;
+            binaryImg.at<std::uint8_t>(v[1], v[0]) = 255;
         }
 
         // Apply closing to fill holes and gaps.
@@ -320,7 +320,7 @@ TFF::PointSet TFF::compute()
         for (const auto p : range2D(closedImg.rows, closedImg.cols)) {
             const auto& x = p.second;
             const auto& y = p.first;
-            if (closedImg.at<uint8_t>(y, x) > 0) {
+            if (closedImg.at<std::uint8_t>(y, x) > 0) {
                 volMask_.emplace_back(x, y, zIndex);
             }
         }
@@ -332,7 +332,7 @@ TFF::PointSet TFF::compute()
             for (const auto v : range2D(closedImg.rows, closedImg.cols)) {
                 const auto& x = v.second;
                 const auto& y = v.first;
-                if (closedImg.at<uint8_t>(y, x) > 0) {
+                if (closedImg.at<std::uint8_t>(y, x) > 0) {
                     i.at<cv::Vec3b>(y, x) = color::BLUE;
                 }
             }

--- a/segmentation/test/CommonTest.cpp
+++ b/segmentation/test/CommonTest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <iostream>
 #include <numeric>
 
@@ -77,7 +78,7 @@ TEST(CommonTest, UnzipTestingSizeTwo)
     std::tie(xs, ys) = Unzip(vs);
     EXPECT_EQ(xs.size(), vs.size());
     EXPECT_EQ(ys.size(), vs.size());
-    for (size_t i = 0; i < vs.size(); ++i) {
+    for (std::size_t i = 0; i < vs.size(); ++i) {
         EXPECT_EQ(xs[i], vs[i](0));
         EXPECT_EQ(ys[i], vs[i](1));
     }

--- a/segmentation/test/CubicSplineTest.cpp
+++ b/segmentation/test/CubicSplineTest.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <cstddef>
 #include <iostream>
 #include <numeric>
 #include <vector>
@@ -13,16 +14,16 @@ using namespace volcart::segmentation;
 // Global float comparison percent tolerance
 static const double floatComparePercentTolerance = 0.01;  // %
 
-std::vector<double> generateTVals(size_t count);
+std::vector<double> generateTVals(std::size_t count);
 
 // Fixture for a spline parameterizing y = 1
 struct ConstantCubicSpline {
 
-    size_t _knotCount;
+    std::size_t _knotCount;
     double _yConstant;
     CubicSpline<double> _spline;
 
-    ConstantCubicSpline(size_t knotCount, double yConstant)
+    ConstantCubicSpline(std::size_t knotCount, double yConstant)
         : _knotCount(knotCount), _yConstant(yConstant), _spline(makeSpline())
     {
         std::vector<double> xs(knotCount), ys(knotCount);
@@ -43,11 +44,11 @@ struct ConstantCubicSpline {
 // Fixture for a spline parameterizing y = x^2
 struct ParabolicCubicSpline {
 
-    size_t _knotCount;
+    std::size_t _knotCount;
     double _splineStart;
     CubicSpline<double> _spline;
 
-    ParabolicCubicSpline(size_t knotCount, double splineStart)
+    ParabolicCubicSpline(std::size_t knotCount, double splineStart)
         : _knotCount(knotCount)
         , _splineStart(splineStart)
         , _spline(makeSpline())
@@ -82,7 +83,7 @@ TEST(CubicSplineTest, CanGenerateCorrectTValues)
     // 1. Check neighbor differences - should be equal
     // Start at 2 so we skip the first pair
     double firstDiff = ts[1] - ts[0];
-    for (size_t i = 2; i < ts.size(); ++i) {
+    for (std::size_t i = 2; i < ts.size(); ++i) {
         volcart::testing::AssertNear(
             firstDiff, ts[i] - ts[i - 1], floatComparePercentTolerance);
     }
@@ -95,14 +96,14 @@ TEST(CubicSplineTest, CanGenerateCorrectTValues)
 // Test constant spline
 TEST(CubicSplineTest, YEqualsOne)
 {
-    size_t count = 10;
+    std::size_t count = 10;
     ConstantCubicSpline s(count, 1.0);
 
     // auto tol = btt::percent_tolerance(floatComparePercentTolerance);
     // auto eps = std::numeric_limits<double>::epsilon();
 
     auto ts = generateTVals(count);
-    for (size_t i = 1; i < ts.size(); ++i) {
+    for (std::size_t i = 1; i < ts.size(); ++i) {
         auto p0 = s._spline(ts[i - 1]);
         auto p1 = s._spline(ts[i]);
 
@@ -131,7 +132,7 @@ TEST(CubicSplineTest, YEqualsOne)
 // Test parabolic spline
 TEST(CubicSplineTest, YEqualsXSquaredValues)
 {
-    size_t count = 20;
+    std::size_t count = 20;
     ParabolicCubicSpline s(count, -10);
     auto ts = generateTVals(count * 2);
     for (auto t : ts) {
@@ -140,7 +141,7 @@ TEST(CubicSplineTest, YEqualsXSquaredValues)
     }
 }
 
-std::vector<double> generateTVals(size_t count)
+std::vector<double> generateTVals(std::size_t count)
 {
     std::vector<double> ts(count);
     ts.front() = 0;

--- a/segmentation/test/DerivativeTest.cpp
+++ b/segmentation/test/DerivativeTest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <iostream>
 #include <numeric>
 
@@ -48,28 +49,28 @@ public:
 
 TEST_F(ConstantDoubleVectorFixture, ConstantD1Forward)
 {
-    for (size_t i = 0; i < _v.size() - 1; ++i) {
+    for (std::size_t i = 0; i < _v.size() - 1; ++i) {
         EXPECT_PRED_FORMAT2(::testing::DoubleLE, D1Forward(_v, i), smallTol);
     }
 }
 
 TEST_F(ConstantDoubleVectorFixture, ConstantD1Backward)
 {
-    for (size_t i = 1; i < _v.size(); ++i) {
+    for (std::size_t i = 1; i < _v.size(); ++i) {
         EXPECT_PRED_FORMAT2(::testing::DoubleLE, D1Backward(_v, i), smallTol);
     }
 }
 
 TEST_F(ConstantDoubleVectorFixture, ConstantD1Central)
 {
-    for (size_t i = 1; i < _v.size() - 1; ++i) {
+    for (std::size_t i = 1; i < _v.size() - 1; ++i) {
         EXPECT_PRED_FORMAT2(::testing::DoubleLE, D1Central(_v, i), smallTol);
     }
 }
 
 TEST_F(ConstantDoubleVectorFixture, ConstantD1FivePointStencil)
 {
-    for (size_t i = 2; i < _v.size() - 2; ++i) {
+    for (std::size_t i = 2; i < _v.size() - 2; ++i) {
         EXPECT_PRED_FORMAT2(
             ::testing::DoubleLE, D1FivePointStencil(_v, i), smallTol);
     }
@@ -77,7 +78,7 @@ TEST_F(ConstantDoubleVectorFixture, ConstantD1FivePointStencil)
 
 TEST_F(ConstantDoubleVectorFixture, ConstantD1At)
 {
-    for (size_t i = 0; i < _v.size(); ++i) {
+    for (std::size_t i = 0; i < _v.size(); ++i) {
         EXPECT_PRED_FORMAT2(::testing::DoubleLE, D1At(_v, i), smallTol);
     }
 }
@@ -94,28 +95,28 @@ TEST_F(ConstantDoubleVectorFixture, ConstantD1)
 
 TEST_F(ConstantDoubleVectorFixture, ConstantD2Forward)
 {
-    for (size_t i = 0; i < _v.size() - 2; ++i) {
+    for (std::size_t i = 0; i < _v.size() - 2; ++i) {
         EXPECT_PRED_FORMAT2(::testing::DoubleLE, D2Forward(_v, i), smallTol);
     }
 }
 
 TEST_F(ConstantDoubleVectorFixture, ConstantD2Backward)
 {
-    for (size_t i = 2; i < _v.size(); ++i) {
+    for (std::size_t i = 2; i < _v.size(); ++i) {
         EXPECT_PRED_FORMAT2(::testing::DoubleLE, D2Backward(_v, i), smallTol);
     }
 }
 
 TEST_F(ConstantDoubleVectorFixture, ConstantD2Central)
 {
-    for (size_t i = 1; i < _v.size() - 1; ++i) {
+    for (std::size_t i = 1; i < _v.size() - 1; ++i) {
         EXPECT_PRED_FORMAT2(::testing::DoubleLE, D2Central(_v, i), smallTol);
     }
 }
 
 TEST_F(ConstantDoubleVectorFixture, ConstantD2FivePointStencil)
 {
-    for (size_t i = 2; i < _v.size() - 2; ++i) {
+    for (std::size_t i = 2; i < _v.size() - 2; ++i) {
         EXPECT_PRED_FORMAT2(
             ::testing::DoubleLE, D2FivePointStencil(_v, i), smallTol);
     }
@@ -123,7 +124,7 @@ TEST_F(ConstantDoubleVectorFixture, ConstantD2FivePointStencil)
 
 TEST_F(ConstantDoubleVectorFixture, ConstantD2At)
 {
-    for (size_t i = 0; i < _v.size(); ++i) {
+    for (std::size_t i = 0; i < _v.size(); ++i) {
         EXPECT_PRED_FORMAT2(::testing::DoubleLE, D2At(_v, i), smallTol);
     }
 }
@@ -143,7 +144,7 @@ TEST_F(ConstantDoubleVectorFixture, ConstantD2)
 // for some c in [x, x+h]. For y = x^2, f''(x) = 2, so error is -1
 TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD1Forward)
 {
-    for (size_t i = 0; i < _ys.size() - 1; ++i) {
+    for (std::size_t i = 0; i < _ys.size() - 1; ++i) {
         volcart::testing::ExpectNear(
             D1Forward(_ys, i), 2 * _xs[i] + 1, percentTol);
     }
@@ -154,7 +155,7 @@ TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD1Forward)
 // for some c in [x, x+h]. For y = x^2, f''(x) = 2, so error is +1
 TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD1Backward)
 {
-    for (size_t i = 1; i < _ys.size(); ++i) {
+    for (std::size_t i = 1; i < _ys.size(); ++i) {
         volcart::testing::ExpectNear(
             D1Backward(_ys, i), 2 * _xs[i] - 1, percentTol);
     }
@@ -165,14 +166,14 @@ TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD1Backward)
 // for some c in [x-h, x+h]. For y = x^2, f'''(x) = 0, so error is 0
 TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD1Central)
 {
-    for (size_t i = 1; i < _ys.size() - 1; ++i) {
+    for (std::size_t i = 1; i < _ys.size() - 1; ++i) {
         volcart::testing::ExpectNear(D1Central(_ys, i), 2 * _xs[i], percentTol);
     }
 }
 
 TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD1FivePointStencil)
 {
-    for (size_t i = 2; i < _ys.size() - 2; ++i) {
+    for (std::size_t i = 2; i < _ys.size() - 2; ++i) {
         volcart::testing::ExpectNear(
             D1FivePointStencil(_ys, i), 2 * _xs[i], percentTol);
     }
@@ -180,7 +181,7 @@ TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD1FivePointStencil)
 
 TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD1At)
 {
-    for (size_t i = 0; i < _ys.size(); ++i) {
+    for (std::size_t i = 0; i < _ys.size(); ++i) {
         if (i == 0) {
             volcart::testing::ExpectNear(
                 D1At(_ys, i), 2 * _xs[i] + 1, percentTol);
@@ -196,7 +197,7 @@ TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD1At)
 TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD1)
 {
     auto res = D1(_ys);
-    for (size_t i = 0; i < _ys.size(); ++i) {
+    for (std::size_t i = 0; i < _ys.size(); ++i) {
         if (i == 0) {
             volcart::testing::ExpectNear(res[i], 2 * _xs[i] + 1, percentTol);
         } else if (i == _ys.size() - 1) {
@@ -212,7 +213,7 @@ TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD1)
 
 TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD2Forward)
 {
-    for (size_t i = 0; i < _ys.size() - 2; ++i) {
+    for (std::size_t i = 0; i < _ys.size() - 2; ++i) {
         volcart::testing::ExpectNear(D2Forward(_ys, i), 2, percentTol);
     }
 }
@@ -222,7 +223,7 @@ TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD2Forward)
 // for some c in [x, x+h]. For y = x^2, f''(x) = 2, so error is +1
 TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD2Backward)
 {
-    for (size_t i = 2; i < _ys.size(); ++i) {
+    for (std::size_t i = 2; i < _ys.size(); ++i) {
         volcart::testing::ExpectNear(D2Backward(_ys, i), 2, percentTol);
     }
 }
@@ -232,21 +233,21 @@ TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD2Backward)
 // for some c in [x-h, x+h]. For y = x^2, f'''(x) = 0, so error is 0
 TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD2Central)
 {
-    for (size_t i = 1; i < _ys.size() - 1; ++i) {
+    for (std::size_t i = 1; i < _ys.size() - 1; ++i) {
         volcart::testing::ExpectNear(D2Central(_ys, i), 2, percentTol);
     }
 }
 
 TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD2FivePointStencil)
 {
-    for (size_t i = 2; i < _ys.size() - 2; ++i) {
+    for (std::size_t i = 2; i < _ys.size() - 2; ++i) {
         volcart::testing::ExpectNear(D2FivePointStencil(_ys, i), 2, percentTol);
     }
 }
 
 TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD2At)
 {
-    for (size_t i = 0; i < _ys.size(); ++i) {
+    for (std::size_t i = 0; i < _ys.size(); ++i) {
         volcart::testing::ExpectNear(D2At(_ys, i), 2, percentTol);
     }
 }
@@ -254,7 +255,7 @@ TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD2At)
 TEST_F(YEqualsXSquaredDoubleVectorFixture, YEqualsXSquaredD2)
 {
     auto res = D2(_ys);
-    for (size_t i = 0; i < _ys.size(); ++i) {
+    for (std::size_t i = 0; i < _ys.size(); ++i) {
         volcart::testing::ExpectNear(res[i], 2, percentTol);
     }
 }

--- a/segmentation/test/EnergyMetricsTest.cpp
+++ b/segmentation/test/EnergyMetricsTest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <iostream>
 
 #include "vc/segmentation/lrps/EnergyMetrics.hpp"
@@ -32,13 +33,13 @@ public:
 
     ConstantFittedCurve()
     {
-        size_t pointCount = 10;
+        std::size_t pointCount = 10;
         double yConstant = 1.0;
         std::vector<double> xs(pointCount), ys(pointCount);
         std::iota(std::begin(xs), std::end(xs), 0.0);
         std::fill(std::begin(ys), std::end(ys), yConstant);
         std::vector<Voxel> vs(pointCount);
-        for (size_t i = 0; i < pointCount; ++i) {
+        for (std::size_t i = 0; i < pointCount; ++i) {
             vs[i] = {xs[i], ys[i], 0};
         }
         _curve = FittedCurve(vs, 0);

--- a/segmentation/test/FittedCurveTest.cpp
+++ b/segmentation/test/FittedCurveTest.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <cstddef>
 #include <iostream>
 #include <numeric>
 #include <vector>
@@ -13,23 +14,23 @@ using namespace volcart::segmentation;
 // Global float comparison percent tolerance
 static const double tol = 0.01;  // %
 
-std::vector<double> makeTVals(size_t count);
+std::vector<double> makeTVals(std::size_t count);
 
 // Fixture for a constant line y = 1
 struct ConstantFittedCurve {
 
-    size_t _pointCount;
+    std::size_t _pointCount;
     double _yConstant;
     FittedCurve _curve;
 
-    ConstantFittedCurve(size_t pointCount, double yConstant)
+    ConstantFittedCurve(std::size_t pointCount, double yConstant)
         : _pointCount(pointCount), _yConstant(yConstant)
     {
         std::vector<double> xs(pointCount), ys(pointCount);
         std::iota(std::begin(xs), std::end(xs), 0.0);
         std::fill(std::begin(ys), std::end(ys), yConstant);
         std::vector<Voxel> vs(pointCount);
-        for (size_t i = 0; i < pointCount; ++i) {
+        for (std::size_t i = 0; i < pointCount; ++i) {
             vs[i] = {xs[i], ys[i], -1};
         }
         _curve = FittedCurve(vs, -1);
@@ -39,16 +40,16 @@ struct ConstantFittedCurve {
 // Generates a curve representing a circle with radius 'r' centered at (0, 0)
 struct CircleFittedCurve {
 
-    size_t _degreeStep;
+    std::size_t _degreeStep;
     double _radius;
-    size_t _pointCount;
+    std::size_t _pointCount;
     FittedCurve _curve;
 
-    CircleFittedCurve(double radius, size_t degreeStep = 1)
+    CircleFittedCurve(double radius, std::size_t degreeStep = 1)
         : _degreeStep(degreeStep), _radius(radius), _pointCount(0)
     {
         std::vector<Voxel> vs;
-        for (size_t deg = 0; deg < 360; deg += degreeStep) {
+        for (std::size_t deg = 0; deg < 360; deg += degreeStep) {
             vs.emplace_back(
                 radius * std::cos(deg * M_PI / 180.0),
                 radius * std::sin(deg * M_PI / 180.0), -1);
@@ -63,7 +64,7 @@ TEST(ConstantFittedCurve, CheckIncreasingXAndConstantYFromInitialCurve)
     const double yConstant = 1;
     auto curve = ConstantFittedCurve(20, yConstant)._curve;
     volcart::testing::ExpectNear(curve(0)(1), yConstant, tol);
-    for (size_t i = 1; i < curve.size(); ++i) {
+    for (std::size_t i = 1; i < curve.size(); ++i) {
         auto prev = curve(i - 1);
         auto curr = curve(i);
         EXPECT_TRUE(prev(0) < curr(0));
@@ -81,7 +82,7 @@ TEST(
 
     double firstDiff = cv::norm(curve(1), curve(0));
     volcart::testing::ExpectNear(evenlySpaced[0](1), yConstant, tol);
-    for (size_t i = 1; i < evenlySpaced.size(); ++i) {
+    for (std::size_t i = 1; i < evenlySpaced.size(); ++i) {
         volcart::testing::ExpectNear(evenlySpaced[i](1), yConstant, tol);
         volcart::testing::ExpectNear(
             cv::norm(evenlySpaced[i], evenlySpaced[i - 1]), firstDiff, tol);
@@ -91,12 +92,12 @@ TEST(
 TEST(ConstantFittedCurve, ReadIncreasingXAndConstantYFrom4xSampledCurve)
 {
     const double yConstant = 1;
-    const size_t npoints = 20;
+    const std::size_t npoints = 20;
     auto curve = ConstantFittedCurve(npoints, yConstant)._curve;
     auto superSampled = curve.sample(npoints * 4);
 
     volcart::testing::ExpectNear(superSampled[0](1), yConstant, tol);
-    for (size_t i = 1; i < superSampled.size(); ++i) {
+    for (std::size_t i = 1; i < superSampled.size(); ++i) {
         auto curr = superSampled[i];
         auto prev = superSampled[i - 1];
         volcart::testing::ExpectNear(curr(1), yConstant, tol);
@@ -107,12 +108,12 @@ TEST(ConstantFittedCurve, ReadIncreasingXAndConstantYFrom4xSampledCurve)
 TEST(ConstantFittedCurve, VerifyWeGetTheSamePointsBackFor100PercentResample)
 {
     const double yConstant = 1;
-    const size_t npoints = 20;
+    const std::size_t npoints = 20;
     auto curve = ConstantFittedCurve(npoints, yConstant)._curve;
     auto beforeResamplePoints = curve.points();
     curve.resample(1.0);
     EXPECT_EQ(curve.points().size(), beforeResamplePoints.size());
-    for (size_t i = 0; i < npoints; ++i) {
+    for (std::size_t i = 0; i < npoints; ++i) {
         volcart::testing::ExpectNear(
             cv::norm(beforeResamplePoints[i]), cv::norm(curve(i)), tol);
     }
@@ -121,7 +122,7 @@ TEST(ConstantFittedCurve, VerifyWeGetTheSamePointsBackFor100PercentResample)
 TEST(ConstantFittedCurve, EvalReturnsIncreasingXAndConstantY)
 {
     const double yConstant = 1;
-    const size_t npoints = 20;
+    const std::size_t npoints = 20;
     auto curve = ConstantFittedCurve(npoints, yConstant)._curve;
     auto ts = makeTVals(50);
 
@@ -137,7 +138,7 @@ TEST(ConstantFittedCurve, EvalReturnsIncreasingXAndConstantY)
 TEST(ConstantFittedCurve, ConstantCurveHasZeroCurvature)
 {
     const double yConstant = 1;
-    const size_t npoints = 20;
+    const std::size_t npoints = 20;
     auto curve = ConstantFittedCurve(npoints, yConstant)._curve;
     for (auto k : curve.curvature()) {
         EXPECT_PRED_FORMAT2(::testing::DoubleLE, k, 1e-6);
@@ -147,7 +148,7 @@ TEST(ConstantFittedCurve, ConstantCurveHasZeroCurvature)
 TEST(ConstantFittedCurve, ConstantCurveHasArcLengthOfNPointsMinusOne)
 {
     const double yConstant = 1;
-    const size_t npoints = 20;
+    const std::size_t npoints = 20;
     auto curve = ConstantFittedCurve(npoints, yConstant)._curve;
     volcart::testing::ExpectNear(curve.arclength(), double(npoints - 1), tol);
 }
@@ -182,13 +183,13 @@ TEST(CircleFittedCurve, EvenlySampledCircleCurveHasEvenlySpacedPoints)
     auto curve = CircleFittedCurve(radius)._curve;
     auto evenlySpaced = curve.evenlySpacePoints();
     auto firstDiff = cv::norm(evenlySpaced[1], evenlySpaced[0]);
-    for (size_t i = 1; i < evenlySpaced.size(); ++i) {
+    for (std::size_t i = 1; i < evenlySpaced.size(); ++i) {
         volcart::testing::ExpectNear(
             cv::norm(evenlySpaced[i], evenlySpaced[i - 1]), firstDiff, tol);
     }
 }
 
-std::vector<double> makeTVals(size_t count)
+std::vector<double> makeTVals(std::size_t count)
 {
     std::vector<double> ts(count);
     ts.front() = 0;

--- a/segmentation/test/IntensityMapTest.cpp
+++ b/segmentation/test/IntensityMapTest.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <numeric>
 #include <vector>
@@ -15,18 +17,18 @@ using namespace volcart::segmentation;
 static const double perc = 0.01;  // %
 
 // Width/height of reslice window
-static const size_t WIDTH = 32;
-static const size_t HEIGHT = 32;
+static const std::size_t WIDTH = 32;
+static const std::size_t HEIGHT = 32;
 
-cv::Mat_<uint16_t> makeLinearIntensityProfile(
-    const std::vector<std::pair<size_t, uint16_t>> maxima);
+cv::Mat_<std::uint16_t> makeLinearIntensityProfile(
+    const std::vector<std::pair<std::size_t, std::uint16_t>> maxima);
 
 // Fixture to generate a reslice
 class ResliceFixture : public ::testing::Test
 {
 public:
-    cv::Mat_<uint16_t> _reslice;
-    ResliceFixture() : _reslice(HEIGHT, WIDTH, uint16_t(0)) {}
+    cv::Mat_<std::uint16_t> _reslice;
+    ResliceFixture() : _reslice(HEIGHT, WIDTH, std::uint16_t(0)) {}
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -34,10 +36,10 @@ public:
 
 TEST_F(ResliceFixture, AllMaxima)
 {
-    std::vector<uint16_t> rowVec{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    cv::Mat_<uint16_t> row = cv::Mat_<uint16_t>(rowVec).t();
+    std::vector<std::uint16_t> rowVec{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    cv::Mat_<std::uint16_t> row = cv::Mat_<std::uint16_t>(rowVec).t();
     row *= 1000;
     row.copyTo(_reslice.row(HEIGHT / 2 + 2));
 
@@ -52,10 +54,10 @@ TEST_F(ResliceFixture, AllMaxima)
 TEST_F(ResliceFixture, OneMaximaInTheMiddle)
 {
     // Make a triangle-shaped row with maxima in the center
-    std::vector<uint16_t> rowVec{0,  0,  0,  0,  0,  0,  0,  2,  4,  8,  10,
-                                 12, 14, 16, 18, 20, 32, 20, 18, 16, 14, 12,
-                                 10, 8,  4,  2,  0,  0,  0,  0,  0,  0};
-    cv::Mat_<uint16_t> row = cv::Mat_<uint16_t>(rowVec).t();
+    std::vector<std::uint16_t> rowVec{
+        0,  0,  0,  0,  0,  0,  0,  2, 4, 8, 10, 12, 14, 16, 18, 20,
+        32, 20, 18, 16, 14, 12, 10, 8, 4, 2, 0,  0,  0,  0,  0,  0};
+    cv::Mat_<std::uint16_t> row = cv::Mat_<std::uint16_t>(rowVec).t();
 
     // Scale it a bit so normalization/histo equalization doesn't flatten
     // values
@@ -73,10 +75,10 @@ TEST_F(ResliceFixture, OneMaximaInTheMiddle)
 TEST_F(ResliceFixture, OneMaximaShifted)
 {
     // Make a triangle-shaped row with maxima in at center + 5
-    std::vector<uint16_t> rowVec{0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
-                                 0,  2,  4,  8,  10, 12, 14, 16, 18, 20, 32,
-                                 20, 18, 16, 14, 12, 10, 8,  4,  2,  0};
-    cv::Mat_<uint16_t> row = cv::Mat_<uint16_t>(rowVec).t();
+    std::vector<std::uint16_t> rowVec{
+        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  2, 4, 8, 10,
+        12, 14, 16, 18, 20, 32, 20, 18, 16, 14, 12, 10, 8, 4, 2, 0};
+    cv::Mat_<std::uint16_t> row = cv::Mat_<std::uint16_t>(rowVec).t();
 
     // Scale it a bit so normalization/histo equalization doesn't flatten values
     row *= 1000;
@@ -95,10 +97,10 @@ TEST_F(ResliceFixture, OneMaximaShifted)
 
 TEST_F(ResliceFixture, TwoMaximaEquallySpacedInPeakRadius)
 {
-    std::vector<uint16_t> rowVec{0,  0,  0,  0,  2,  4, 8,  10, 12, 14, 16,
-                                 18, 20, 32, 20, 10, 0, 10, 20, 32, 20, 18,
-                                 16, 14, 12, 10, 8,  4, 2,  0,  0,  0};
-    cv::Mat_<uint16_t> row = cv::Mat_<uint16_t>(rowVec).t();
+    std::vector<std::uint16_t> rowVec{0,  0,  0,  0,  2,  4, 8,  10, 12, 14, 16,
+                                      18, 20, 32, 20, 10, 0, 10, 20, 32, 20, 18,
+                                      16, 14, 12, 10, 8,  4, 2,  0,  0,  0};
+    cv::Mat_<std::uint16_t> row = cv::Mat_<std::uint16_t>(rowVec).t();
     row *= 1000;
     row.copyTo(_reslice.row(HEIGHT / 2 + 1));
 
@@ -112,10 +114,10 @@ TEST_F(ResliceFixture, TwoMaximaEquallySpacedInPeakRadius)
 
 TEST_F(ResliceFixture, TwoMaximaOneInsidePeakRadius)
 {
-    std::vector<uint16_t> rowVec{0,  0,  0,  0,  2,  4, 8, 10, 12, 14, 16,
-                                 18, 20, 32, 20, 14, 8, 2, 0,  2,  8,  14,
-                                 20, 24, 32, 16, 8,  4, 2, 1,  0,  0};
-    cv::Mat_<uint16_t> row = cv::Mat_<uint16_t>(rowVec).t();
+    std::vector<std::uint16_t> rowVec{0,  0,  0,  0,  2,  4, 8, 10, 12, 14, 16,
+                                      18, 20, 32, 20, 14, 8, 2, 0,  2,  8,  14,
+                                      20, 24, 32, 16, 8,  4, 2, 1,  0,  0};
+    cv::Mat_<std::uint16_t> row = cv::Mat_<std::uint16_t>(rowVec).t();
     row *= 1000;
     row.copyTo(_reslice.row(HEIGHT / 2 + 1));
 
@@ -128,10 +130,10 @@ TEST_F(ResliceFixture, TwoMaximaOneInsidePeakRadius)
 
 TEST_F(ResliceFixture, TwoMaximaOneCloserToMiddle)
 {
-    std::vector<uint16_t> rowVec{0,  0,  0,  0,  2,  4, 8,  10, 12, 14, 16,
-                                 18, 20, 32, 20, 10, 0, 32, 28, 24, 20, 18,
-                                 16, 14, 12, 10, 8,  4, 2,  0,  0,  0};
-    cv::Mat_<uint16_t> row = cv::Mat_<uint16_t>(rowVec).t();
+    std::vector<std::uint16_t> rowVec{0,  0,  0,  0,  2,  4, 8,  10, 12, 14, 16,
+                                      18, 20, 32, 20, 10, 0, 32, 28, 24, 20, 18,
+                                      16, 14, 12, 10, 8,  4, 2,  0,  0,  0};
+    cv::Mat_<std::uint16_t> row = cv::Mat_<std::uint16_t>(rowVec).t();
     row *= 1000;
     row.copyTo(_reslice.row(HEIGHT / 2 + 1));
 
@@ -145,10 +147,10 @@ TEST_F(ResliceFixture, TwoMaximaOneCloserToMiddle)
 
 TEST_F(ResliceFixture, TwoMaximaOneCloserToMiddleButShorter)
 {
-    std::vector<uint16_t> rowVec{0,  0,  0,  0,  2,  4, 8, 10, 12, 14, 16,
-                                 18, 20, 32, 20, 10, 0, 5, 14, 12, 10, 8,
-                                 4,  2,  0,  0,  0,  0, 0, 0,  0,  0};
-    cv::Mat_<uint16_t> row = cv::Mat_<uint16_t>(rowVec).t();
+    std::vector<std::uint16_t> rowVec{0,  0,  0,  0,  2,  4, 8, 10, 12, 14, 16,
+                                      18, 20, 32, 20, 10, 0, 5, 14, 12, 10, 8,
+                                      4,  2,  0,  0,  0,  0, 0, 0,  0,  0};
+    cv::Mat_<std::uint16_t> row = cv::Mat_<std::uint16_t>(rowVec).t();
     row *= 1000;
     row.copyTo(_reslice.row(HEIGHT / 2 + 1));
 

--- a/segmentation/test/LocalResliceParticleSimTest.cpp
+++ b/segmentation/test/LocalResliceParticleSimTest.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <cstddef>
 
 #include "vc/core/types/VolumePkg.hpp"
 #include "vc/segmentation/LocalResliceParticleSim.hpp"
@@ -88,8 +89,8 @@ TEST_F(LocalResliceSegmentationFix, DefaultSegmentationTest)
     // Compare clouds, make sure each point is within a certain tolerance.
     // Currently set in this file, may be set outside later on
     constexpr double voxelDiffTol = 10;  // %
-    size_t diffCount = 0;
-    for (size_t i = 0; i < groundTruthCloud.size(); ++i) {
+    std::size_t diffCount = 0;
+    for (std::size_t i = 0; i < groundTruthCloud.size(); ++i) {
         PointXYZ trueV(groundTruthCloud[i]);
         PointXYZ testV(resultCloud[i]);
         auto xdiff = std::abs(trueV.x - testV.x);
@@ -110,7 +111,7 @@ TEST_F(LocalResliceSegmentationFix, DefaultSegmentationTest)
 
     // Check that the clouds never vary in point differences by 10%
     auto maxAllowedDiffCount =
-        size_t(std::round(0.1 * groundTruthCloud.size()));
+        std::size_t(std::round(0.1 * groundTruthCloud.size()));
     std::cout << "# different points: " << diffCount
               << " (max allowed: " << maxAllowedDiffCount << ")" << std::endl;
     EXPECT_TRUE(diffCount < maxAllowedDiffCount);

--- a/testing/src/ParsingHelpers.cpp
+++ b/testing/src/ParsingHelpers.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstddef>
 #include <fstream>
 #include <iostream>
 #include <vector>
@@ -124,7 +125,8 @@ void ParsingHelpers::ParsePLYFile(
 
             // Read in the vertex information
             for (int v = 0; v < numVertices; v++) {
-                for (size_t i = 0; i < typeOfPointInformation.size(); i++) {
+                for (std::size_t i = 0; i < typeOfPointInformation.size();
+                     i++) {
 
                     if (typeOfPointInformation[i] == "x") {
                         plyVertex.x = std::stod(plyLine[i]);

--- a/testing/test/ParsingHelpersTest.cpp
+++ b/testing/test/ParsingHelpersTest.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cstddef>
+
 #include "vc/core/io/OBJWriter.hpp"
 #include "vc/core/io/PLYWriter.hpp"
 #include "vc/core/shapes/Plane.hpp"
@@ -38,7 +40,7 @@ TEST_F(PlaneFixture, ParseOBJTest)
 
     // Check Points and Normals
     EXPECT_EQ(_input->GetNumberOfPoints(), _SavedPoints.size());
-    for (size_t pnt_id = 0; pnt_id < _SavedPoints.size(); pnt_id++) {
+    for (std::size_t pnt_id = 0; pnt_id < _SavedPoints.size(); pnt_id++) {
         EXPECT_DOUBLE_EQ(_input->GetPoint(pnt_id)[0], _SavedPoints[pnt_id].x);
         EXPECT_DOUBLE_EQ(_input->GetPoint(pnt_id)[1], _SavedPoints[pnt_id].y);
         EXPECT_DOUBLE_EQ(_input->GetPoint(pnt_id)[2], _SavedPoints[pnt_id].z);
@@ -55,7 +57,7 @@ TEST_F(PlaneFixture, ParseOBJTest)
     // Check Cells, Checks Point normals by ensuring that the first vertex is
     // the same in both
     EXPECT_EQ(_input->GetNumberOfCells(), _SavedCells.size());
-    for (size_t cell_id = 0; cell_id < _SavedCells.size(); cell_id++) {
+    for (std::size_t cell_id = 0; cell_id < _SavedCells.size(); cell_id++) {
         ITKCell::CellAutoPointer current_C;
         _input->GetCell(cell_id, current_C);
         EXPECT_EQ(current_C->GetPointIds()[0], _SavedCells[cell_id].v1);
@@ -79,7 +81,7 @@ TEST_F(PlaneFixture, ParsePLYTest)
 
     // Check Points and Normals
     EXPECT_EQ(_input->GetNumberOfPoints(), _SavedPoints.size());
-    for (size_t pnt_id = 0; pnt_id < _SavedPoints.size(); pnt_id++) {
+    for (std::size_t pnt_id = 0; pnt_id < _SavedPoints.size(); pnt_id++) {
         EXPECT_DOUBLE_EQ(_input->GetPoint(pnt_id)[0], _SavedPoints[pnt_id].x);
         EXPECT_DOUBLE_EQ(_input->GetPoint(pnt_id)[1], _SavedPoints[pnt_id].y);
         EXPECT_DOUBLE_EQ(_input->GetPoint(pnt_id)[2], _SavedPoints[pnt_id].z);
@@ -96,7 +98,7 @@ TEST_F(PlaneFixture, ParsePLYTest)
     // Check Cells, Checks Point normals by ensuring that the first vertex is
     // the same in both
     EXPECT_EQ(_SavedCells.size(), _input->GetNumberOfCells());
-    for (size_t cell_id = 0; cell_id < _SavedCells.size(); cell_id++) {
+    for (std::size_t cell_id = 0; cell_id < _SavedCells.size(); cell_id++) {
         ITKCell::CellAutoPointer current_C;
         _input->GetCell(cell_id, current_C);
         EXPECT_EQ(current_C->GetPointIds()[0], _SavedCells[cell_id].v1);

--- a/texturing/include/vc/texturing/AngleBasedFlattening.hpp
+++ b/texturing/include/vc/texturing/AngleBasedFlattening.hpp
@@ -2,6 +2,7 @@
 
 /** @file */
 
+#include <cstddef>
 #include <memory>
 
 #include <opencv2/core.hpp>

--- a/texturing/include/vc/texturing/FlatteningError.hpp
+++ b/texturing/include/vc/texturing/FlatteningError.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 /** @file */
+#include <cstdint>
 
 #include <opencv2/core.hpp>
 
@@ -31,7 +32,7 @@ cv::Mat PlotPerFaceError(
     cv::Mat output(cellMap.rows, cellMap.cols, CV_32FC1);
     output = cv::Scalar::all(defaultValue);
     for (const auto& [y, x] : range2D(cellMap.rows, cellMap.cols)) {
-        auto cell = cellMap.at<int32_t>(y, x);
+        auto cell = cellMap.at<std::int32_t>(y, x);
         if (cell >= 0) {
             auto error = errorMap.at(cell);
             output.at<float>(y, x) = static_cast<float>(error);

--- a/texturing/include/vc/texturing/IntegralTexture.hpp
+++ b/texturing/include/vc/texturing/IntegralTexture.hpp
@@ -2,9 +2,10 @@
 
 /** @file */
 
-#include "vc/texturing/TexturingAlgorithm.hpp"
+#include <cstdint>
 
 #include "vc/core/neighborhood/NeighborhoodGenerator.hpp"
+#include "vc/texturing/TexturingAlgorithm.hpp"
 
 namespace volcart::texturing
 {
@@ -99,12 +100,12 @@ public:
      *
      * Ignored if setClampValuesToMax() is set to `false`
      *
-     * Default: std::numeric_limits<uint16_t>::max()
+     * Default: std::numeric_limits<std::uint16_t>::max()
      */
-    void setClampMax(uint16_t m);
+    void setClampMax(std::uint16_t m);
 
-    /** @copydoc setClampMax(uint16_t) */
-    [[nodiscard]] auto clampMax() const -> uint16_t;
+    /** @copydoc setClampMax(std::uint16_t) */
+    [[nodiscard]] auto clampMax() const -> std::uint16_t;
 
     /**
      * @brief Set the weighting method
@@ -179,7 +180,7 @@ private:
     bool clampToMax_{false};
 
     /** Maximum allowed value in neighborhood when clamping is enabled */
-    uint16_t clampMax_{std::numeric_limits<uint16_t>::max()};
+    std::uint16_t clampMax_{std::numeric_limits<uint16_t>::max()};
 
     /** Selected Weighting method */
     WeightMethod weight_{WeightMethod::None};
@@ -221,7 +222,7 @@ private:
     void setup_expodiff_weights_();
 
     /** Get the list of intensities on the surface of the mesh */
-    auto expodiff_intersection_pts_() -> std::vector<uint16_t>;
+    auto expodiff_intersection_pts_() -> std::vector<std::uint16_t>;
 
     /** Calculate the mean base value */
     auto expodiff_mean_base_() -> double;

--- a/texturing/include/vc/texturing/PPMGenerator.hpp
+++ b/texturing/include/vc/texturing/PPMGenerator.hpp
@@ -2,6 +2,8 @@
 
 /** @file */
 
+#include <cstddef>
+
 #include "vc/core/types/ITKMesh.hpp"
 #include "vc/core/types/Mixins.hpp"
 #include "vc/core/types/PerPixelMap.hpp"
@@ -42,7 +44,7 @@ public:
     PPMGenerator() = default;
 
     /** Construct with dimension parameters */
-    PPMGenerator(size_t h, size_t w);
+    PPMGenerator(std::size_t h, std::size_t w);
     /**@}*/
 
     /**@{*/
@@ -55,7 +57,7 @@ public:
 
     /**@{*/
     /** @brief Set the dimensions of the output PPM */
-    void setDimensions(size_t h, size_t w);
+    void setDimensions(std::size_t h, std::size_t w);
 
     /** @brief Set the normal shading method */
     void setShading(Shading s);
@@ -72,7 +74,7 @@ public:
     /**@}*/
 
     /** @brief Returns the maximum progress value */
-    [[nodiscard]] auto progressIterations() const -> size_t override;
+    [[nodiscard]] auto progressIterations() const -> std::size_t override;
 
 private:
     /** Input mesh */
@@ -87,9 +89,9 @@ private:
     /** Output shading */
     Shading shading_{Shading::Smooth};
     /** Output width of the PerPixelMap */
-    size_t width_{0};
+    std::size_t width_{0};
     /** Output height of the PerPixelMap */
-    size_t height_{0};
+    std::size_t height_{0};
 };
 
 /**

--- a/texturing/src/CompositeTexture.cpp
+++ b/texturing/src/CompositeTexture.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 
 #include "vc/core/util/FloatComparison.hpp"
 #include "vc/core/util/Iteration.hpp"
@@ -52,9 +53,10 @@ auto FilterMedianMean(Neighborhood n, double range) -> std::uint16_t
     std::sort(n.begin(), n.end());
 
     // The number of things we're going to sum
-    auto count = static_cast<size_t>(std::ceil(n.size() * range));
+    auto count = static_cast<std::size_t>(std::ceil(n.size() * range));
     // The number of things before we start summing
-    auto offset = static_cast<size_t>(std::floor((n.size() - count) / 2.0));
+    auto offset =
+        static_cast<std::size_t>(std::floor((n.size() - count) / 2.0));
 
     // Sum
     auto sum = std::accumulate(

--- a/texturing/src/IntegralTexture.cpp
+++ b/texturing/src/IntegralTexture.cpp
@@ -1,6 +1,7 @@
 #include "vc/texturing/IntegralTexture.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <map>
 #include <set>
 
@@ -53,7 +54,7 @@ auto IntegralTexture::compute() -> Texture
         if (clampToMax_) {
             std::replace_if(
                 n.begin(), n.end(),
-                [this](uint16_t v) { return v > clampMax_; }, clampMax_);
+                [this](std::uint16_t v) { return v > clampMax_; }, clampMax_);
         }
 
         // Convert to double and weight the neighborhood
@@ -159,10 +160,10 @@ void IntegralTexture::setup_expodiff_weights_()
     }
 }
 
-auto IntegralTexture::expodiff_intersection_pts_() -> std::vector<uint16_t>
+auto IntegralTexture::expodiff_intersection_pts_() -> std::vector<std::uint16_t>
 {
     // Get all the intensity values
-    std::vector<uint16_t> values;
+    std::vector<std::uint16_t> values;
     for (const auto [y, x] : ppm_->getMappingCoords()) {
         const auto& m = ppm_->getMapping(y, x);
         values.emplace_back(vol_->interpolateAt({m[0], m[1], m[2]}));
@@ -177,7 +178,7 @@ auto IntegralTexture::expodiff_mean_base_() -> double
     auto values = expodiff_intersection_pts_();
 
     // Calculate the mean
-    size_t n = 0;
+    std::size_t n = 0;
     double mean = 0.0;
     for (const auto& v : values) {
         double delta = v - mean;
@@ -193,7 +194,7 @@ auto IntegralTexture::expodiff_mode_base_() -> double
     auto values = expodiff_intersection_pts_();
 
     // Generate a histogram
-    std::map<uint16_t, int> histogram;
+    std::map<std::uint16_t, int> histogram;
     for (const auto& v : values) {
         try {
             histogram.at(v) += 1;
@@ -203,7 +204,7 @@ auto IntegralTexture::expodiff_mode_base_() -> double
     }
 
     // Sort by frequency high to low
-    using KVPair = std::pair<uint16_t, int>;
+    using KVPair = std::pair<std::uint16_t, int>;
     using Comparator = std::function<bool(KVPair, KVPair)>;
     Comparator compare = [](KVPair a, KVPair b) { return a.second > b.second; };
     std::set<KVPair, Comparator> sorter(
@@ -243,9 +244,9 @@ void IntegralTexture::setClampValuesToMax(bool b) { clampToMax_ = b; }
 
 auto IntegralTexture::clampValuesToMax() const -> bool { return clampToMax_; }
 
-void IntegralTexture::setClampMax(uint16_t m) { clampMax_ = m; }
+void IntegralTexture::setClampMax(std::uint16_t m) { clampMax_ = m; }
 
-auto IntegralTexture::clampMax() const -> uint16_t { return clampMax_; }
+auto IntegralTexture::clampMax() const -> std::uint16_t { return clampMax_; }
 
 void IntegralTexture::setWeightMethod(IntegralTexture::WeightMethod w)
 {

--- a/texturing/src/IntersectionTexture.cpp
+++ b/texturing/src/IntersectionTexture.cpp
@@ -1,6 +1,8 @@
 #include "vc/texturing/IntersectionTexture.hpp"
 
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
 
 using namespace volcart;
 using namespace volcart::texturing;
@@ -40,7 +42,7 @@ Texture IntersectionTexture::compute()
 
         // Assign the intensity value at the XY position
         const auto& m = ppm_->getMapping(y, x);
-        image.at<uint16_t>(static_cast<int>(y), static_cast<int>(x)) =
+        image.at<std::uint16_t>(static_cast<int>(y), static_cast<int>(x)) =
             vol_->interpolateAt({m[0], m[1], m[2]});
     }
     progressComplete();

--- a/texturing/src/LayerTexture.cpp
+++ b/texturing/src/LayerTexture.cpp
@@ -1,5 +1,7 @@
 #include "vc/texturing/LayerTexture.hpp"
 
+#include <cstddef>
+
 #include <opencv2/core.hpp>
 
 #include "vc/core/util/Iteration.hpp"
@@ -19,7 +21,7 @@ auto LayerTexture::compute() -> Texture
     auto width = static_cast<int>(ppm_->width());
 
     // Setup output images
-    for (size_t i = 0; i < gen_->extents()[0]; i++) {
+    for (std::size_t i = 0; i < gen_->extents()[0]; i++) {
         result_.emplace_back(cv::Mat::zeros(height, width, CV_16UC1));
     }
 

--- a/texturing/src/OrthographicProjectionFlattening.cpp
+++ b/texturing/src/OrthographicProjectionFlattening.cpp
@@ -43,7 +43,7 @@ ITKMesh::Pointer OrthographicProjectionFlattening::compute()
     auto vVec = yAxis / vLen;
     ITKPoint oldPt;
     ITKPoint newPt;
-    for (size_t i = 0; i < mesh_->GetNumberOfPoints(); ++i) {
+    for (std::size_t i = 0; i < mesh_->GetNumberOfPoints(); ++i) {
         // Get the original point
         mesh_->GetPoint(i, &oldPt);
         cv::Vec3d pt(oldPt.GetDataPointer());

--- a/texturing/src/PPMGenerator.cpp
+++ b/texturing/src/PPMGenerator.cpp
@@ -1,5 +1,6 @@
 #include "vc/texturing/PPMGenerator.hpp"
 
+#include <cstdint>
 #include <exception>
 
 #include <bvh/bvh.hpp>
@@ -21,7 +22,7 @@ using namespace texturing;
 namespace vcm = volcart::meshing;
 namespace vct = volcart::texturing;
 
-static constexpr uint8_t MASK_TRUE{255};
+static constexpr std::uint8_t MASK_TRUE{255};
 
 using Scalar = double;
 using Vector3 = bvh::Vector3<Scalar>;
@@ -31,14 +32,16 @@ using Bvh = bvh::Bvh<Scalar>;
 using Intersector = bvh::ClosestPrimitiveIntersector<Bvh, Triangle>;
 using Traverser = bvh::SingleRayTraverser<Bvh>;
 
-PPMGenerator::PPMGenerator(size_t h, size_t w) : width_{w}, height_{h} {}
+PPMGenerator::PPMGenerator(std::size_t h, std::size_t w) : width_{w}, height_{h}
+{
+}
 
 void PPMGenerator::setMesh(const ITKMesh::Pointer& m) { inputMesh_ = m; }
 
 void PPMGenerator::setUVMap(const UVMap::Pointer& u) { uvMap_ = u; }
 
 // Parameters
-void PPMGenerator::setDimensions(size_t h, size_t w)
+void PPMGenerator::setDimensions(std::size_t h, std::size_t w)
 {
     height_ = h;
     width_ = w;
@@ -48,7 +51,7 @@ void PPMGenerator::setShading(PPMGenerator::Shading s) { shading_ = s; }
 
 auto PPMGenerator::getPPM() const -> PerPixelMap::Pointer { return ppm_; }
 
-auto PPMGenerator::progressIterations() const -> size_t
+auto PPMGenerator::progressIterations() const -> std::size_t
 {
     return width_ * height_;
 }
@@ -172,10 +175,10 @@ auto PPMGenerator::compute() -> PerPixelMap::Pointer
         // Assign the cell index to the cell map
         auto intX = static_cast<int>(x);
         auto intY = static_cast<int>(y);
-        cellMap.at<int32_t>(intY, intX) = cellId;
+        cellMap.at<std::int32_t>(intY, intX) = cellId;
 
         // Assign the intensity value at the UV position
-        mask.at<uint8_t>(intY, intX) = MASK_TRUE;
+        mask.at<std::uint8_t>(intY, intX) = MASK_TRUE;
 
         // Assign 3D position to the lookup map
         ppm_->getMapping(y, x) = cv::Vec6d(
@@ -245,7 +248,7 @@ auto vct::GenerateCellMap(
         // Assign the cell index to the cell map
         auto intX = static_cast<int>(x);
         auto intY = static_cast<int>(y);
-        cellMap.at<int32_t>(intY, intX) =
+        cellMap.at<std::int32_t>(intY, intX) =
             static_cast<int>(hit->primitive_index);
     }
 

--- a/texturing/src/ProjectMesh.cpp
+++ b/texturing/src/ProjectMesh.cpp
@@ -1,5 +1,6 @@
 #include "vc/texturing/ProjectMesh.hpp"
 
+#include <cstdint>
 #include <utility>
 
 #include <bvh/bvh.hpp>
@@ -16,7 +17,7 @@
 #include "vc/core/util/Iteration.hpp"
 #include "vc/meshing/ITK2VTK.hpp"
 
-static constexpr uint8_t MASK_TRUE{255};
+static constexpr std::uint8_t MASK_TRUE{255};
 
 using Scalar = double;
 using Vector3 = bvh::Vector3<Scalar>;
@@ -219,12 +220,12 @@ auto vct::ProjectMesh::compute() -> vc::PerPixelMap
         // Assign the cell index to the cell map
         auto intU = static_cast<int>(u);
         auto intV = static_cast<int>(v);
-        cellMap.at<int32_t>(intV, intU) = static_cast<int>(cellId);
+        cellMap.at<std::int32_t>(intV, intU) = static_cast<int>(cellId);
 
         // Assign 3D position to the lookup map and update the mask
         outputPPM_(v, u) = cv::Vec6d{xyz(0),     xyz(1),     xyz(2),
                                      xyzNorm(0), xyzNorm(1), xyzNorm(2)};
-        mask.at<uint8_t>(v, u) = MASK_TRUE;
+        mask.at<std::uint8_t>(v, u) = MASK_TRUE;
     }
 
     outputPPM_.setMask(mask);

--- a/texturing/test/ABFTest.cpp
+++ b/texturing/test/ABFTest.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <cstddef>
+
 #include "vc/core/shapes/Arch.hpp"
 #include "vc/core/shapes/Plane.hpp"
 #include "vc/core/types/SimpleMesh.hpp"
@@ -139,7 +141,7 @@ TEST_F(CreatePlaneABFUVFixture, PlaneABFUVTest)
     EXPECT_EQ(_out_Mesh->GetNumberOfPoints(), _SavedPoints.size());
 
     // check uvmap against original mesh input pointIDs
-    for (size_t point = 0; point < _SavedPoints.size(); ++point) {
+    for (std::size_t point = 0; point < _SavedPoints.size(); ++point) {
 
         volcart::testing::SmallOrClose(
             _out_Mesh->GetPoint(point)[0], _SavedPoints[point].x);
@@ -158,7 +160,7 @@ TEST_F(CreatePlaneABFLSCMOnlyUVFixture, PlaneABFLSCMOnlyUVTest)
     EXPECT_EQ(_out_Mesh->GetNumberOfPoints(), _SavedPoints.size());
 
     // check uvmap against original mesh input pointIDs
-    for (size_t point = 0; point < _SavedPoints.size(); ++point) {
+    for (std::size_t point = 0; point < _SavedPoints.size(); ++point) {
 
         volcart::testing::SmallOrClose(
             _out_Mesh->GetPoint(point)[0], _SavedPoints[point].x);
@@ -177,7 +179,7 @@ TEST_F(CreateArchABFUVFixture, ArchABFUVTest)
     EXPECT_EQ(_out_Mesh->GetNumberOfPoints(), _SavedPoints.size());
 
     // check uvmap against original mesh input pointIDs
-    for (size_t point = 0; point < _SavedPoints.size(); ++point) {
+    for (std::size_t point = 0; point < _SavedPoints.size(); ++point) {
 
         volcart::testing::SmallOrClose(
             _out_Mesh->GetPoint(point)[0], _SavedPoints[point].x);
@@ -196,7 +198,7 @@ TEST_F(CreateArchABFLSCMOnlyUVFixture, ArchABFLSCMOnlyUVTest)
     EXPECT_EQ(_out_Mesh->GetNumberOfPoints(), _SavedPoints.size());
 
     // check uvmap against original mesh input pointIDs
-    for (size_t point = 0; point < _SavedPoints.size(); ++point) {
+    for (std::size_t point = 0; point < _SavedPoints.size(); ++point) {
 
         volcart::testing::SmallOrClose(
             _out_Mesh->GetPoint(point)[0], _SavedPoints[point].x);

--- a/texturing/test/PPMGeneratorTest.cpp
+++ b/texturing/test/PPMGeneratorTest.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 
 #include "vc/core/shapes/Plane.hpp"
 #include "vc/core/util/Iteration.hpp"
@@ -48,8 +50,8 @@ TEST(PPMGeneratorTest, RegressionTest)
 
         EXPECT_EQ(ppm->getMapping(y, x), expected(y, x));
         EXPECT_EQ(
-            ppm->cellMap().at<int32_t>(y, x),
-            expected.cellMap().at<int32_t>(y, x));
+            ppm->cellMap().at<std::int32_t>(y, x),
+            expected.cellMap().at<std::int32_t>(y, x));
     }
 }
 
@@ -63,7 +65,7 @@ TEST_P(PPMGeneratorTest, PerformanceTest)
 
     // Generate UV map
     auto uvMap = vc::UVMap::New();
-    size_t pID = 0;
+    std::size_t pID = 0;
     for (int y = 0; y < GetParam(); y++) {
         auto v = double(y) / (GetParam() - 1);
         for (int x = 0; x < GetParam(); x++) {

--- a/utils/src/AlignmentMarkers.cpp
+++ b/utils/src/AlignmentMarkers.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <exception>
 #include <iostream>
 #include <regex>
@@ -126,7 +127,7 @@ int main(int argc, char* argv[])
 
     // Save all of the images
     vc::Logger()->info("Saving alignment marked outputs...");
-    for (size_t idx = 0; idx < imgs.size(); idx++) {
+    for (std::size_t idx = 0; idx < imgs.size(); idx++) {
         // Get the file name
         auto path = fs::path(meshPaths[idx]).filename();
 

--- a/utils/src/ApplyColorMap.cpp
+++ b/utils/src/ApplyColorMap.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <limits>
 
@@ -14,19 +16,22 @@ using namespace volcart;
 namespace fs = volcart::filesystem;
 namespace po = boost::program_options;
 
-static inline float ValueMax(int cvDepth)
+namespace
+{
+float ValueMax(int cvDepth)
 {
     switch (cvDepth) {
         case CV_8U:
-            return std::numeric_limits<uint8_t>::max();
+            return std::numeric_limits<std::uint8_t>::max();
         case CV_16U:
-            return std::numeric_limits<uint16_t>::max();
+            return std::numeric_limits<std::uint16_t>::max();
         case CV_32F:
             return 1.F;
         default:
             return 255;
     }
 }
+}  // namespace
 
 int main(int argc, char* argv[])
 {

--- a/utils/src/ConvertMask.cpp
+++ b/utils/src/ConvertMask.cpp
@@ -1,6 +1,8 @@
 // vc_convert_mask: Bidirectional conversion between Point Mask (.vcps) and
 // Volume Mask (Image sequence)
 
+#include <cstddef>
+#include <cstdint>
 #include <map>
 #include <regex>
 #include <sstream>
@@ -27,9 +29,9 @@ void PointMaskToVolumeMask(
     const fs::path& outDir,
     const vc::Volume::Pointer& volume);
 void WriteMaskImage(
-    int idx, size_t pad, const fs::path& dir, const cv::Mat& img);
+    int idx, std::size_t pad, const fs::path& dir, const cv::Mat& img);
 
-using SliceList = std::map<size_t, fs::path>;
+using SliceList = std::map<std::size_t, fs::path>;
 void VolumeMaskToPointMask(const fs::path& inPath, const fs::path& outPath);
 SliceList CollectVolumeFiles(const fs::path& fmtPath);
 
@@ -135,7 +137,7 @@ void PointMaskToVolumeMask(
 
     // Mask the images
     vc::Logger()->info("Converting mask");
-    size_t pad = std::to_string(volume->numSlices()).size();
+    std::size_t pad = std::to_string(volume->numSlices()).size();
     int sliceNum{pts[0][2]};
     cv::Size sliceSize(volume->sliceWidth(), volume->sliceHeight());
     cv::Mat slice = cv::Mat::zeros(sliceSize, CV_8UC1);
@@ -150,13 +152,13 @@ void PointMaskToVolumeMask(
             slice = cv::Mat::zeros(sliceSize, CV_8UC1);
         }
 
-        slice.at<uint8_t>(p[1], p[0]) = 255;
+        slice.at<std::uint8_t>(p[1], p[0]) = 255;
     }
     WriteMaskImage(sliceNum, pad, outDir, slice);
 }
 
 void WriteMaskImage(
-    int idx, size_t pad, const fs::path& dir, const cv::Mat& img)
+    int idx, std::size_t pad, const fs::path& dir, const cv::Mat& img)
 {
     // Construct the file name
     std::ostringstream file;
@@ -188,7 +190,7 @@ void VolumeMaskToPointMask(const fs::path& inPath, const fs::path& outPath)
         for (const auto px : vc::range2D(img.rows, img.cols)) {
             const auto& x = px.second;
             const auto& y = px.first;
-            if (img.at<uint8_t>(y, x) > 0) {
+            if (img.at<std::uint8_t>(y, x) > 0) {
                 pts.emplace_back(x, y, z);
             }
         }
@@ -219,7 +221,7 @@ SliceList CollectVolumeFiles(const fs::path& fmtPath)
         auto filename = subfile->path().filename().string();
         std::smatch matches;
         if (std::regex_match(filename, matches, filter)) {
-            size_t idx = std::stoull(matches[1].str());
+            std::size_t idx = std::stoull(matches[1].str());
             paths[idx] = subfile->path();
         }
     }

--- a/utils/src/ConvertPointSet.cpp
+++ b/utils/src/ConvertPointSet.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <cstdint>
 
 #include <boost/program_options.hpp>
 
@@ -82,7 +83,7 @@ void PointSetToMesh(const fs::path& inputPath, const fs::path& outputPath)
     vc::Logger()->info("Loaded PointSet with {} points", inputCloud.size());
 
     // Add vertex intensity
-    std::vector<uint16_t> intensities;
+    std::vector<std::uint16_t> intensities;
     if (PARSED.count("volpkg")) {
         // Load the volume package
         auto volpkgPath = PARSED["volpkg"].as<std::string>();

--- a/utils/src/GenerateColorMapBar.cpp
+++ b/utils/src/GenerateColorMapBar.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <iostream>
 
 #include <boost/program_options.hpp>

--- a/utils/src/ImageStatistics.cpp
+++ b/utils/src/ImageStatistics.cpp
@@ -1,4 +1,6 @@
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <numeric>
@@ -93,7 +95,7 @@ int main(int argc, char* argv[])
         const auto& y = pixel.first;
 
         // Skip if we have a mask and this pixel isn't in it
-        if (not mask.empty() and mask.at<uint8_t>(y, x) == 0) {
+        if (not mask.empty() and mask.at<std::uint8_t>(y, x) == 0) {
             continue;
         }
 
@@ -108,7 +110,7 @@ int main(int argc, char* argv[])
         for (const auto it : enumerate(classMasks)) {
             const auto& idx = it.first;
             const auto& cmask = it.second;
-            if (cmask.at<uint8_t>(y, x) > 0) {
+            if (cmask.at<std::uint8_t>(y, x) > 0) {
                 classVals[idx].push_back(val);
             }
         }
@@ -158,7 +160,7 @@ int main(int argc, char* argv[])
     file << "class,count,mean,var,std_dev,median" << std::endl;
     for (const auto it : vc::enumerate(metrics)) {
         file << classNames[it.first] << ",";
-        file << static_cast<size_t>(it.second.at("count")) << ",";
+        file << static_cast<std::size_t>(it.second.at("count")) << ",";
         file << it.second.at("mean") << ",";
         file << it.second.at("var") << ",";
         file << it.second.at("std_dev") << ",";
@@ -171,15 +173,15 @@ float GetValue(int x, int y, const cv::Mat& m)
 {
     switch (m.depth()) {
         case CV_8U:
-            return m.at<uint8_t>(y, x);
+            return m.at<std::uint8_t>(y, x);
         case CV_8S:
-            return m.at<int8_t>(y, x);
+            return m.at<std::int8_t>(y, x);
         case CV_16U:
-            return m.at<uint16_t>(y, x);
+            return m.at<std::uint16_t>(y, x);
         case CV_16S:
-            return m.at<int16_t>(y, x);
+            return m.at<std::int16_t>(y, x);
         case CV_32S:
-            return m.at<int32_t>(y, x);
+            return m.at<std::int32_t>(y, x);
         case CV_32F:
             return m.at<float>(y, x);
         case CV_64F:

--- a/utils/src/InvertCloud.cpp
+++ b/utils/src/InvertCloud.cpp
@@ -1,6 +1,7 @@
 // invertcloud.cpp
 // Seth Parker, Aug 2015
 
+#include <cstddef>
 #include <fstream>
 #include <iostream>
 
@@ -40,8 +41,8 @@ int main(int argc, char** argv)
 
     // Flip the rows
     vc::OrderedPointSet<cv::Vec3d> output(input.width());
-    for (size_t r = 0; r < input.height(); r++) {
-        size_t index = input.height() - 1 - r;
+    for (std::size_t r = 0; r < input.height(); r++) {
+        std::size_t index = input.height() - 1 - r;
         output.pushRow(input.getRow(index));
     }
 

--- a/utils/src/PPMTool.cpp
+++ b/utils/src/PPMTool.cpp
@@ -47,9 +47,11 @@ auto ParseROI(const std::string& opt) -> ROI
         std::exit(EXIT_FAILURE);
     }
 
-    return {
-        std::stoull(strs[2]), std::stoull(strs[3]), std::stoull(strs[0]),
-        std::stoull(strs[1])};
+    const auto x = static_cast<std::size_t>(std::stoull(strs[2]));
+    const auto y = static_cast<std::size_t>(std::stoull(strs[3]));
+    const auto w = static_cast<std::size_t>(std::stoull(strs[0]));
+    const auto h = static_cast<std::size_t>(std::stoull(strs[1]));
+    return {x, y, w, h};
 }
 }  // namespace
 
@@ -140,10 +142,10 @@ auto main(int argc, char* argv[]) -> int
     const auto writeMesh = IsFileType(outPath, {"obj", "ply"});
 
     // Setup ROI
-    size_t minX = 0;
-    size_t minY = 0;
-    size_t maxX = ppm.width();
-    size_t maxY = ppm.height();
+    std::size_t minX = 0;
+    std::size_t minY = 0;
+    std::size_t maxX = ppm.width();
+    std::size_t maxY = ppm.height();
     if (parsed.count("roi") > 0) {
         auto roi = ::ParseROI(parsed["roi"].as<std::string>());
         minX = std::max(minX, roi.x);

--- a/utils/src/RepairPointSets.cpp
+++ b/utils/src/RepairPointSets.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+
 #include <boost/program_options.hpp>
 
 #include "vc/core/filesystem.hpp"

--- a/utils/src/SegToPointMask.cpp
+++ b/utils/src/SegToPointMask.cpp
@@ -1,3 +1,6 @@
+#include <cstddef>
+#include <cstdint>
+
 #include <boost/program_options.hpp>
 #include <opencv2/core.hpp>
 
@@ -15,7 +18,7 @@ namespace vc = volcart;
 namespace vcs = volcart::segmentation;
 
 void WriteMaskImage(
-    int idx, size_t pad, const fs::path& dir, const cv::Mat& img);
+    int idx, std::size_t pad, const fs::path& dir, const cv::Mat& img);
 
 int main(int argc, char* argv[])
 {
@@ -36,15 +39,15 @@ int main(int argc, char* argv[])
     // TFF options
     po::options_description tffOptions("Thinned Flood Fill Segmentation Options");
     tffOptions.add_options()
-        ("low-thresh,l", po::value<uint16_t>()->default_value(14135),
+        ("low-thresh,l", po::value<std::uint16_t>()->default_value(14135),
              "Low threshold for the bounded flood-fill component [0-255]")
-        ("high-thresh,t", po::value<uint16_t>()->default_value(65535),
+        ("high-thresh,t", po::value<std::uint16_t>()->default_value(65535),
              "High threshold for the bounded flood-fill component [0-255]")
         ("enable-closing", po::value<bool>()->default_value(true),
              "If enabled, perform morphological mask closing.")
         ("closing-kernel-size,k", po::value<int>()->default_value(5),
              "Size of the kernel used for closing")
-        ("max-seed-radius", po::value<size_t>(),
+        ("max-seed-radius", po::value<std::size_t>(),
             "Max radius a seed point can have when measuring the thickness of the page.")
         ("measure-vert", "Measure the thickness of the page by going vertically (+/- y) "
             "from each seed point (measures horizontally by default)");
@@ -104,12 +107,12 @@ int main(int argc, char* argv[])
     vcs::ComputeVolumetricMask maskGen;
     maskGen.setPointSet(segmentation);
     maskGen.setVolume(volume);
-    maskGen.setLowThreshold(parsed["low-thresh"].as<uint16_t>());
-    maskGen.setHighThreshold(parsed["high-thresh"].as<uint16_t>());
+    maskGen.setLowThreshold(parsed["low-thresh"].as<std::uint16_t>());
+    maskGen.setHighThreshold(parsed["high-thresh"].as<std::uint16_t>());
     maskGen.setEnableClosing(parsed["enable-closing"].as<bool>());
     maskGen.setClosingKernelSize(parsed["closing-kernel-size"].as<int>());
     if (parsed.count("max-seed-radius") > 0) {
-        auto r = parsed["max-seed-radius"].as<size_t>();
+        auto r = parsed["max-seed-radius"].as<std::size_t>();
         maskGen.setMaxRadius(r);
     }
     maskGen.setMeasureVertical(parsed.count("measure-vert") > 0);

--- a/utils/src/VolumeBump.cpp
+++ b/utils/src/VolumeBump.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <cstddef>
 #include <iomanip>
 #include <limits>
 #include <map>
@@ -23,10 +24,10 @@ namespace vc = volcart;
 
 // Volpkg version required by this app
 static constexpr int VOLPKG_MIN_VERSION = 6;
-static const double MAX_16BPC = std::numeric_limits<uint16_t>::max();
+static const double MAX_16BPC = std::numeric_limits<std::uint16_t>::max();
 
 fs::path g_outputDir;
-size_t g_numSliceChars;
+std::size_t g_numSliceChars;
 
 void WriteBumpedSlice(const cv::Mat& slice, int index);
 
@@ -98,7 +99,7 @@ int main(int argc, char* argv[])
     g_numSliceChars = std::to_string(volume->numSlices()).size();
 
     // Set the cache size
-    size_t cacheBytes;
+    std::size_t cacheBytes;
     if (parsed.count("cache-memory-limit")) {
         auto cacheSizeOpt = parsed["cache-memory-limit"].as<std::string>();
         cacheBytes = vc::MemorySizeStringParser(cacheSizeOpt);
@@ -170,10 +171,12 @@ int main(int argc, char* argv[])
         }
 
         // Use the bump mask as an opacity function on the bumpVal
-        auto bumpOpacity = bumpMask.at<uint16_t>(pixel.y, pixel.x) / MAX_16BPC;
-        auto bumped = currentSlice.at<uint16_t>(y, x) + bumpOpacity * bumpVal;
-        currentSlice.at<uint16_t>(y, x) =
-            static_cast<uint16_t>(std::min(bumped, MAX_16BPC));
+        auto bumpOpacity =
+            bumpMask.at<std::uint16_t>(pixel.y, pixel.x) / MAX_16BPC;
+        auto bumped =
+            currentSlice.at<std::uint16_t>(y, x) + bumpOpacity * bumpVal;
+        currentSlice.at<std::uint16_t>(y, x) =
+            static_cast<std::uint16_t>(std::min(bumped, MAX_16BPC));
     }
 
     // Write the last slice image


### PR DESCRIPTION
* Change all instances of `size_t` to `std::size_t` and `#include <cstddef>`
* Add `std::` to all fixed width integer types and `#include <cstdint>`
* Update to smgl v0.10.1 which incorporates similar changes.

@oceanusxiv please give this a try and let me know if I missed any includes.

Fixes #73 