### PR TITLE
Modernize with trailing return types

### DIFF
--- a/app_support/src/GetMemorySize.cpp
+++ b/app_support/src/GetMemorySize.cpp
@@ -28,7 +28,7 @@
 #endif
 
 /* Returns the size of physical memory (RAM) in bytes. */
-std::size_t SystemMemorySize()
+auto SystemMemorySize() -> std::size_t
 {
 
 #if defined(_WIN32) && (defined(__CYGWIN__) || defined(__CYGWIN32__))

--- a/apps/Canny/CannySegment.cpp
+++ b/apps/Canny/CannySegment.cpp
@@ -76,7 +76,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") != 0 || argc < 4) {
-        std::cerr << all << std::endl;
+        std::cerr << all << '\n';
         return EXIT_SUCCESS;
     }
 
@@ -84,7 +84,7 @@ auto main(int argc, char* argv[]) -> int
     try {
         po::notify(parsed);
     } catch (po::error& e) {
-        std::cerr << "ERROR: " << e.what() << std::endl;
+        std::cerr << "ERROR: " << e.what() << '\n';
         return EXIT_FAILURE;
     }
 
@@ -133,8 +133,8 @@ auto main(int argc, char* argv[]) -> int
         std::cerr << "Cannot load volume. ";
         std::cerr << "Please check that the Volume Package has volumes and "
                      "that the volume ID is correct."
-                  << std::endl;
-        std::cerr << e.what() << std::endl;
+                  << '\n';
+        std::cerr << e.what() << '\n';
         return EXIT_FAILURE;
     }
 

--- a/apps/Projection/Projection.cpp
+++ b/apps/Projection/Projection.cpp
@@ -73,7 +73,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if ((parsed.count("help") > 0) || argc < 4) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 
@@ -139,8 +139,8 @@ auto main(int argc, char* argv[]) -> int
         std::cerr << "Cannot load volume. ";
         std::cerr << "Please check that the Volume Package has volumes and "
                      "that the volume ID is correct."
-                  << std::endl;
-        std::cerr << e.what() << std::endl;
+                  << '\n';
+        std::cerr << e.what() << '\n';
         return EXIT_FAILURE;
     }
     auto width = volume->sliceWidth();

--- a/apps/VC/CBezierCurve.cpp
+++ b/apps/VC/CBezierCurve.cpp
@@ -14,7 +14,7 @@
 using namespace ChaoVis;
 
 // Bezier point
-inline float GetPt(int n1, int n2, float percent)
+inline auto GetPt(int n1, int n2, float percent) -> float
 {
     int diff = n2 - n1;
     return n1 + (diff * percent);

--- a/apps/VC/CSimpleNumEditBox.cpp
+++ b/apps/VC/CSimpleNumEditBox.cpp
@@ -32,7 +32,7 @@ CSimpleNumEditBox::CSimpleNumEditBox(QWidget* parent)
 CSimpleNumEditBox::~CSimpleNumEditBox(void) {}
 
 // Get slice index from text
-int CSimpleNumEditBox::GetImageIndexFromText(void)
+auto CSimpleNumEditBox::GetImageIndexFromText(void) -> int
 {
     int aResult;
     bool aIsOk = false;  // invalid
@@ -45,7 +45,7 @@ int CSimpleNumEditBox::GetImageIndexFromText(void)
 }
 
 // Get slice index
-int CSimpleNumEditBox::GetImageIndex(void) { return fImageIndex; }
+auto CSimpleNumEditBox::GetImageIndex(void) -> int { return fImageIndex; }
 
 // Set slice index
 void CSimpleNumEditBox::SetImageIndex(int nImageIndex)

--- a/apps/VC/CVolumeViewerWithCurve.cpp
+++ b/apps/VC/CVolumeViewerWithCurve.cpp
@@ -300,8 +300,8 @@ void CVolumeViewerWithCurve::WidgetLoc2ImgLoc(
 }
 
 // Select point on curve
-int CVolumeViewerWithCurve::SelectPointOnCurve(
-    const CXCurve* nCurve, const cv::Vec2f& nPt)
+auto CVolumeViewerWithCurve::SelectPointOnCurve(
+    const CXCurve* nCurve, const cv::Vec2f& nPt) -> int
 {
     const double DIST_THRESHOLD = 1.5 * fScaleFactor;
 

--- a/apps/VC/CWindow.cpp
+++ b/apps/VC/CWindow.cpp
@@ -484,7 +484,7 @@ void CWindow::setWidgetsEnabled(bool state)
     fVolumeViewerWidget->setButtonsEnabled(state);
 }
 
-bool CWindow::InitializeVolumePkg(const std::string& nVpkgPath)
+auto CWindow::InitializeVolumePkg(const std::string& nVpkgPath) -> bool
 {
     fVpkg = nullptr;
 
@@ -513,7 +513,7 @@ void CWindow::setDefaultWindowWidth(vc::Volume::Pointer volume)
     fEdtWindowWidth->setValue(static_cast<int>(winWidth));
 }
 
-CWindow::SaveResponse CWindow::SaveDialog(void)
+auto CWindow::SaveDialog(void) -> CWindow::SaveResponse
 {
     // Return if nothing has changed
     if (not fVpkgChanged) {
@@ -771,7 +771,7 @@ void CWindow::CleanupSegmentation(void)
 }
 
 // Set up the parameters for doing segmentation
-bool CWindow::SetUpSegParams(void)
+auto CWindow::SetUpSegParams(void) -> bool
 {
     bool aIsOk;
 
@@ -1394,7 +1394,7 @@ void CWindow::OnPathChanged(void)
     }
 }
 
-bool CWindow::can_change_volume_()
+auto CWindow::can_change_volume_() -> bool
 {
     return fVpkg != nullptr && fVpkg->numberOfVolumes() > 1 &&
            (fSegmentation == nullptr || !fSegmentation->hasPointSet() ||

--- a/apps/VC/UDataManipulateUtils.cpp
+++ b/apps/VC/UDataManipulateUtils.cpp
@@ -13,7 +13,7 @@ namespace ChaoVis
 {
 
 // Split vertex and face to memory chunk that can fit into OpenGL
-bool SplitVertexAndElementBuffer(
+auto SplitVertexAndElementBuffer(
     int /*nVertexNum*/,
     int nFaceNum,
     const int* nElementBufferTmp,  // constant data, not constant pointer
@@ -25,7 +25,7 @@ bool SplitVertexAndElementBuffer(
     int** nElementBufferSize,
     int** nVertexBufferSize,
     int** nUVBufferSize,
-    int* nElementArrayNum)
+    int* nElementArrayNum) -> bool
 {
     const unsigned short MAX_NUM_FACE_IN_ARRAY = USHORT_SIZE / 3;
 
@@ -110,7 +110,7 @@ bool SplitVertexAndElementBuffer(
 }
 
 // Convert from QImage to cv::Mat
-cv::Mat QImage2Mat(const QImage& nSrc)
+auto QImage2Mat(const QImage& nSrc) -> cv::Mat
 {
     cv::Mat tmp(
         nSrc.height(), nSrc.width(), CV_8UC3, const_cast<uchar*>(nSrc.bits()),
@@ -121,7 +121,7 @@ cv::Mat QImage2Mat(const QImage& nSrc)
 }
 
 // Convert from cv::Mat to QImage
-QImage Mat2QImage(const cv::Mat& nSrc)
+auto Mat2QImage(const cv::Mat& nSrc) -> QImage
 {
     cv::Mat tmp;
     cvtColor(nSrc, tmp, cv::COLOR_BGR2RGB);  // copy and convert color space

--- a/apps/include/vc/apps/server/VolumeServer.hpp
+++ b/apps/include/vc/apps/server/VolumeServer.hpp
@@ -58,7 +58,7 @@ private:
     std::size_t memory_;
 
     /** Generate a string for representing a socket. */
-    std::string socketStr_(QTcpSocket* socket);
+    auto socketStr_(QTcpSocket* socket) -> std::string;
 
     /** Resolve a single sub-volume request. */
     void resolveRequest_(QTcpSocket* socket, protocol::RequestArgs* args);

--- a/apps/src/GeneratePPM.cpp
+++ b/apps/src/GeneratePPM.cpp
@@ -38,7 +38,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") > 0 || argc < 3) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 

--- a/apps/src/Mesher.cpp
+++ b/apps/src/Mesher.cpp
@@ -40,7 +40,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") > 0 || argc < 2) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 

--- a/apps/src/Metadata.cpp
+++ b/apps/src/Metadata.cpp
@@ -13,7 +13,7 @@ namespace po = boost::program_options;
 namespace fs = volcart::filesystem;
 namespace vc = volcart;
 
-int main(int argc, char* argv[])
+auto main(int argc, char* argv[]) -> int
 {
     // clang-format off
     po::options_description options{"options arguments"};

--- a/apps/src/Metadata.cpp
+++ b/apps/src/Metadata.cpp
@@ -38,8 +38,8 @@ auto main(int argc, char* argv[]) -> int
     // Print help
     if (argc == 1 || opts.count("help")) {
         std::cout << "Usage: " << argv[0]
-                  << " [options] key=value [key=value ...]" << std::endl;
-        std::cout << options << std::endl;
+                  << " [options] key=value [key=value ...]" << '\n';
+        std::cout << options << '\n';
         std::exit(1);
     }
 
@@ -47,7 +47,7 @@ auto main(int argc, char* argv[]) -> int
     try {
         po::notify(opts);
     } catch (po::error& e) {
-        std::cerr << "ERROR: " << e.what() << std::endl;
+        std::cerr << "ERROR: " << e.what() << '\n';
         return EXIT_FAILURE;
     }
 
@@ -55,7 +55,7 @@ auto main(int argc, char* argv[]) -> int
     if (opts.count("test") + opts.count("write") > 1) {
         std::cerr
             << "Multiple modes specified. Only pick one of [print/test/write]"
-            << std::endl;
+            << '\n';
         std::exit(1);
     }
 
@@ -72,7 +72,7 @@ auto main(int argc, char* argv[]) -> int
     // Test or write metadata
     if (opts.count("test") || opts.count("write")) {
         if (!opts.count("configs")) {
-            std::cout << "No metadata changes to make, exiting" << std::endl;
+            std::cout << "No metadata changes to make, exiting" << '\n';
             std::exit(0);
         }
         auto configs = opts["configs"].as<std::vector<std::string>>();
@@ -115,7 +115,7 @@ auto main(int argc, char* argv[]) -> int
         auto types_it = vc::VERSION_LIBRARY.find(volpkg.version());
         if (types_it == std::end(vc::VERSION_LIBRARY)) {
             std::cerr << "Could not find type mapping for version "
-                      << volpkg.version() << std::endl;
+                      << volpkg.version() << '\n';
             std::exit(1);
         }
         auto typeMap = types_it->second;
@@ -150,18 +150,17 @@ auto main(int argc, char* argv[]) -> int
 
         // Only print, don't save.
         if (opts.count("test")) {
-            std::cout << "Final metadata: " << std::endl;
+            std::cout << "Final metadata: " << '\n';
             volpkg.metadata().printObject();
-            std::cout << std::endl;
+            std::cout << '\n';
             return EXIT_SUCCESS;
         }
 
         // Actually save.
         if (opts.count("write")) {
-            std::cout << "Writing metadata to file..." << std::endl;
+            std::cout << "Writing metadata to file..." << '\n';
             volpkg.saveMetadata();
-            std::cout << "Metadata written successfully." << std::endl
-                      << std::endl;
+            std::cout << "Metadata written successfully." << '\n' << '\n';
             return EXIT_SUCCESS;
         }
     }

--- a/apps/src/Packager.cpp
+++ b/apps/src/Packager.cpp
@@ -171,7 +171,7 @@ auto main(int argc, char* argv[]) -> int
     AddVolume(volpkg, info);
 }
 
-VolumeInfo GetVolumeInfo(const po::variables_map& parsed)
+auto GetVolumeInfo(const po::variables_map& parsed) -> VolumeInfo
 {
     VolumeInfo info;
 

--- a/apps/src/Packager.cpp
+++ b/apps/src/Packager.cpp
@@ -98,7 +98,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") || argc < 2) {
-        std::cout << helpOpts << std::endl;
+        std::cout << helpOpts << '\n';
         return EXIT_SUCCESS;
     }
 
@@ -106,7 +106,7 @@ auto main(int argc, char* argv[]) -> int
     try {
         po::notify(parsed);
     } catch (po::error& e) {
-        std::cerr << "ERROR: " << e.what() << std::endl;
+        std::cerr << "ERROR: " << e.what() << '\n';
         return EXIT_FAILURE;
     }
 
@@ -129,7 +129,7 @@ auto main(int argc, char* argv[]) -> int
         if (parsed.count("material-thickness") == 0) {
             std::cerr << "ERROR: Making a new volume package but did not "
                          "provide the material thickness."
-                      << std::endl;
+                      << '\n';
             return EXIT_FAILURE;
         }
         volpkg = vc::VolumePkg::New(volpkgPath, vc::VOLPKG_VERSION_LATEST);
@@ -217,7 +217,8 @@ auto GetVolumeInfo(const po::variables_map& parsed) -> VolumeInfo
 
     // Volume Name
     if (parsed.count("volume-name") == 0) {
-        std::cerr << "ERROR: --volume-name required when creating a new volume." << std::endl;
+        std::cerr << "ERROR: --volume-name required when creating a new volume."
+                  << '\n';
         exit(EXIT_FAILURE);
     }
     info.name = parsed["volume-name"].as<std::string>();
@@ -225,7 +226,9 @@ auto GetVolumeInfo(const po::variables_map& parsed) -> VolumeInfo
     // Get voxel size
     if (!voxelFound) {
         if (parsed.count("voxel-size-um") == 0) {
-            std::cerr << "ERROR: --voxel-size-um required when creating a new volume." << std::endl;
+            std::cerr
+                << "ERROR: --voxel-size-um required when creating a new volume."
+                << '\n';
             exit(EXIT_FAILURE);
         }
         info.voxelsize = parsed["voxel-size-um"].as<double>();

--- a/apps/src/ProjectMesh.cpp
+++ b/apps/src/ProjectMesh.cpp
@@ -48,7 +48,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") > 0 || argc < 2) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 

--- a/apps/src/Segment.cpp
+++ b/apps/src/Segment.cpp
@@ -133,7 +133,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Display help
     if (argc == 1 || parsed.count("help")) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         std::exit(1);
     }
 
@@ -145,7 +145,7 @@ auto main(int argc, char* argv[]) -> int
     // Check mutually exclusive arguments
     if (parsed.count("end-index") && parsed.count("stride")) {
         std::cerr << "[error]: 'end-index' and 'stride' are mutually exclusive"
-                  << std::endl;
+                  << '\n';
         std::exit(1);
     }
 
@@ -153,7 +153,7 @@ auto main(int argc, char* argv[]) -> int
     try {
         po::notify(parsed);
     } catch (po::error& e) {
-        std::cerr << "[error]: " << e.what() << std::endl;
+        std::cerr << "[error]: " << e.what() << '\n';
         return EXIT_FAILURE;
     }
 
@@ -168,7 +168,7 @@ auto main(int argc, char* argv[]) -> int
     } else {
         std::cerr
             << "[error]: Unknown algorithm type. Must be one of ['LRPS', 'TFF']"
-            << std::endl;
+            << '\n';
         std::exit(1);
     }
 
@@ -194,8 +194,8 @@ auto main(int argc, char* argv[]) -> int
         seg = vpkg.segmentation(segID);
     } catch (const std::exception& e) {
         std::cerr << "Cannot load segmentation. ";
-        std::cerr << "Please check the provided ID: " << segID << std::endl;
-        std::cerr << e.what() << std::endl;
+        std::cerr << "Please check the provided ID: " << segID << '\n';
+        std::cerr << e.what() << '\n';
         return EXIT_FAILURE;
     }
 
@@ -219,8 +219,8 @@ auto main(int argc, char* argv[]) -> int
         std::cerr << "Cannot load volume. ";
         std::cerr << "Please check that the Volume Package has volumes and "
                      "that the volume ID is correct. "
-                  << volID << std::endl;
-        std::cerr << e.what() << std::endl;
+                  << volID << '\n';
+        std::cerr << e.what() << '\n';
         return EXIT_FAILURE;
     }
 

--- a/apps/src/Segment.cpp
+++ b/apps/src/Segment.cpp
@@ -52,7 +52,7 @@ static void WritePointset(const PointSet& pointset);
 static void WriteIntermediatePointset(const PointSet& pointset);
 static void WriteMaskPointset(const VoxelMask& pointset);
 
-int main(int argc, char* argv[])
+auto main(int argc, char* argv[]) -> int
 {
     // Set up options
     // clang-format off

--- a/apps/src/SliceImage.cpp
+++ b/apps/src/SliceImage.cpp
@@ -14,12 +14,12 @@ static const double MAX_16BPC = std::numeric_limits<std::uint16_t>::max();
 namespace volcart
 {
 
-bool SliceImage::operator==(const SliceImage& b) const
+auto SliceImage::operator==(const SliceImage& b) const -> bool
 {
     return (w_ == b.w_ && h_ == b.h_ && type_ == b.type_);
 }
 
-bool SliceImage::operator<(const SliceImage& b) const
+auto SliceImage::operator<(const SliceImage& b) const -> bool
 {
     auto aName = to_lower_copy(path.filename().string());
     auto bName = to_lower_copy(b.path.filename().string());
@@ -34,7 +34,7 @@ bool SliceImage::operator<(const SliceImage& b) const
     return aName.size() < bName.size();
 }
 
-bool SliceImage::analyze()
+auto SliceImage::analyze() -> bool
 {
     // return if the path is wrong or if this isn't a regular file
     if (!(volcart::filesystem::exists(path)) ||
@@ -65,7 +65,7 @@ bool SliceImage::analyze()
     return true;
 }
 
-cv::Mat SliceImage::conformedImage()
+auto SliceImage::conformedImage() -> cv::Mat
 {
     // Load the image
     auto image =

--- a/apps/src/VolumeClientApp.cpp
+++ b/apps/src/VolumeClientApp.cpp
@@ -32,7 +32,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") || argc < 5) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 

--- a/apps/src/VolumeClientApp.cpp
+++ b/apps/src/VolumeClientApp.cpp
@@ -13,7 +13,7 @@ namespace fs = volcart::filesystem;
 namespace po = boost::program_options;
 namespace vc = volcart;
 
-int main(int argc, char* argv[])
+auto main(int argc, char* argv[]) -> int
 {
     // clang-format off
     po::options_description required("General Options");

--- a/apps/src/VolumeServer.cpp
+++ b/apps/src/VolumeServer.cpp
@@ -12,7 +12,7 @@
 
 namespace vc = volcart;
 
-std::string vc::VolumeServer::socketStr_(QTcpSocket* socket)
+auto vc::VolumeServer::socketStr_(QTcpSocket* socket) -> std::string
 {
     return "[" + socket->peerAddress().toString().toStdString() + ":" +
            std::to_string(socket->peerPort()) + "]: ";

--- a/apps/src/VolumeServerApp.cpp
+++ b/apps/src/VolumeServerApp.cpp
@@ -20,7 +20,7 @@ namespace vc = volcart;
 // Volpkg version required by this app
 static constexpr int VOLPKG_MIN_VERSION = 6;
 
-int main(int argc, char* argv[])
+auto main(int argc, char* argv[]) -> int
 {
     // Add CLI arguments
     // clang-format off

--- a/apps/src/VolumeServerApp.cpp
+++ b/apps/src/VolumeServerApp.cpp
@@ -42,7 +42,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") || argc < 2) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 

--- a/core/include/vc/core/types/LRUCache.hpp
+++ b/core/include/vc/core/types/LRUCache.hpp
@@ -63,10 +63,13 @@ public:
     explicit LRUCache(std::size_t capacity) : BaseClass(capacity) {}
 
     /** @overload LRUCache() */
-    static Pointer New() { return std::make_shared<LRUCache<TKey, TValue>>(); }
+    static auto New() -> Pointer
+    {
+        return std::make_shared<LRUCache<TKey, TValue>>();
+    }
 
     /** @overload LRUCache(std::size_t) */
-    static Pointer New(std::size_t capacity)
+    static auto New(std::size_t capacity) -> Pointer
     {
         return std::make_shared<LRUCache<TKey, TValue>>(capacity);
     }
@@ -92,15 +95,15 @@ public:
     }
 
     /** @brief Get the maximum number of elements in the cache */
-    std::size_t capacity() const override { return capacity_; }
+    auto capacity() const -> std::size_t override { return capacity_; }
 
     /** @brief Get the current number of elements in the cache */
-    std::size_t size() const override { return lookup_.size(); }
+    auto size() const -> std::size_t override { return lookup_.size(); }
     /**@}*/
 
     /**@{*/
     /** @brief Get an item from the cache by key */
-    TValue get(const TKey& k) override
+    auto get(const TKey& k) -> TValue override
     {
         auto lookupIter = lookup_.find(k);
         if (lookupIter == std::end(lookup_)) {
@@ -133,7 +136,7 @@ public:
     }
 
     /** @brief Check if an item is already in the cache */
-    bool contains(const TKey& k) override
+    auto contains(const TKey& k) -> bool override
     {
         return lookup_.find(k) != std::end(lookup_);
     }

--- a/core/include/vc/core/types/NDArray.hpp
+++ b/core/include/vc/core/types/NDArray.hpp
@@ -110,18 +110,18 @@ public:
     }
 
     /** @brief Get the number of dimensions of the array */
-    std::size_t dims() const { return dim_; }
+    auto dims() const -> std::size_t { return dim_; }
 
     /** @brief Get the extent (size) of the array's dimensions */
-    Extent extents() const { return extents_; }
+    auto extents() const -> Extent { return extents_; }
 
     /** @brief Get the total number of elements in the array */
-    std::size_t size() const { return data_.size(); }
+    auto size() const -> std::size_t { return data_.size(); }
     /**@}*/
 
     /**@{*/
     /** @brief Per-element access */
-    T& operator()(Index index)
+    auto operator()(Index index) -> T&
     {
 
         if (index.size() != dim_) {
@@ -131,7 +131,7 @@ public:
     }
 
     /** @overload T& operator()(Index index) */
-    const T& operator()(Index index) const
+    auto operator()(Index index) const -> const T&
     {
         if (index.size() != dim_) {
             throw std::invalid_argument("Index of wrong dimension");
@@ -141,20 +141,20 @@ public:
 
     /** @overload T& operator()(Index index) */
     template <typename... Is>
-    T& operator()(Is... indices)
+    auto operator()(Is... indices) -> T&
     {
         return operator()(Index{static_cast<IndexType>(indices)...});
     }
 
     /** @overload T& operator()(Index index) */
     template <typename... Is>
-    const T& operator()(Is... indices) const
+    auto operator()(Is... indices) const -> const T&
     {
         return operator()(Index{static_cast<IndexType>(indices)...});
     }
 
     /** @brief Get slice of array by dropping highest dimension */
-    NDArray slice(IndexType index)
+    auto slice(IndexType index) -> NDArray
     {
         auto offset = std::accumulate(
             std::next(extents_.begin(), 1), extents_.end(), IndexType(1),
@@ -171,45 +171,48 @@ public:
 
     /**@{*/
     /** @brief Return copy of raw data */
-    Container as_vector() { return data_; }
+    auto as_vector() -> Container { return data_; }
 
     /** @overload as_vector() */
-    Container as_vector() const { return data_; }
+    auto as_vector() const -> Container { return data_; }
 
     /** @brief Get a pointer to the start of the underlying data */
-    typename Container::value_type* data() { return data_.data(); }
+    auto data() -> typename Container::value_type* { return data_.data(); }
 
     /** @overload data() */
-    typename Container::value_type* data() const { return data_.data(); }
+    auto data() const -> typename Container::value_type*
+    {
+        return data_.data();
+    }
 
     /**
      * @brief Return an iterator that points to the first element in the array
      */
-    iterator begin() { return std::begin(data_); }
+    auto begin() -> iterator { return std::begin(data_); }
 
     /** @copydoc begin() */
-    const_iterator begin() const { return std::begin(data_); }
+    auto begin() const -> const_iterator { return std::begin(data_); }
 
     /**
      * @brief Return an iterator that points to the \em past-the-end element
      * in the array
      */
-    iterator end() { return std::end(data_); }
+    auto end() -> iterator { return std::end(data_); }
 
     /** @copydoc end() */
-    const_iterator end() const { return std::end(data_); }
+    auto end() const -> const_iterator { return std::end(data_); }
 
     /** @brief Return a reference to the first element in the array */
-    T& front() { return data_.front(); }
+    auto front() -> T& { return data_.front(); }
 
     /** @copydoc front() */
-    const T& front() const { return data_.front(); }
+    auto front() const -> const T& { return data_.front(); }
 
     /** @brief Return a reference to the last element in the array */
-    T& back() { return data_.back(); }
+    auto back() -> T& { return data_.back(); }
 
     /** @copydoc back() */
-    const T& back() const { return data_.back(); }
+    auto back() const -> const T& { return data_.back(); }
     /**@}*/
 
     /**
@@ -262,7 +265,7 @@ private:
     }
 
     /** Convert item index to data index */
-    inline IndexType index_to_data_index_(Index i) const
+    inline auto index_to_data_index_(Index i) const -> IndexType
     {
         IndexType idx{0};
         for (std::size_t it = 0; it < extents_.size(); it++) {

--- a/core/src/ApplyLUT.cpp
+++ b/core/src/ApplyLUT.cpp
@@ -11,7 +11,7 @@ using namespace volcart;
 namespace vc = volcart;
 
 // Calculate the LUT bin a value belongs in
-static int ValueToBin(float value, float min, float max, int bins)
+static auto ValueToBin(float value, float min, float max, int bins) -> int
 {
     // End points are easy
     if (value == max) {
@@ -33,8 +33,9 @@ static int ValueToBin(float value, float min, float max, int bins)
     return static_cast<int>(bin);
 }
 
-cv::Mat vc::ApplyLUT(
+auto vc::ApplyLUT(
     const cv::Mat& img, const cv::Mat& lut, float min, float max, bool invert)
+    -> cv::Mat
 {
     // Validate the LUT
     if (lut.depth() != CV_8U) {
@@ -80,13 +81,13 @@ cv::Mat vc::ApplyLUT(
     return output;
 }
 
-cv::Mat vc::ApplyLUT(
+auto vc::ApplyLUT(
     const cv::Mat& img,
     const cv::Mat& lut,
     float min,
     float mid,
     float max,
-    bool invert)
+    bool invert) -> cv::Mat
 {
     // Validate the LUT
     if (lut.depth() != CV_8U) {
@@ -142,8 +143,9 @@ cv::Mat vc::ApplyLUT(
     return output;
 }
 
-cv::Mat vc::ApplyLUT(
+auto vc::ApplyLUT(
     const cv::Mat& img, const cv::Mat& lut, bool invert, const cv::Mat& mask)
+    -> cv::Mat
 {
     // Default min/max
     double min{0};
@@ -157,8 +159,9 @@ cv::Mat vc::ApplyLUT(
         img, lut, static_cast<float>(min), static_cast<float>(max), invert);
 }
 
-cv::Mat vc::GenerateLUTScaleBar(
+auto vc::GenerateLUTScaleBar(
     const cv::Mat& lut, bool invert, std::size_t height, std::size_t width)
+    -> cv::Mat
 {
     // Construct a single row
     auto maxDim = static_cast<int>(std::max(width, height));

--- a/core/src/BarycentricCoordinates.cpp
+++ b/core/src/BarycentricCoordinates.cpp
@@ -7,11 +7,11 @@ namespace vc = volcart;
 // From Christer Ericson's Real-Time Collision Detection
 // Code from:
 // http://gamedev.stackexchange.com/questions/23743/whats-the-most-efficient-way-to-find-barycentric-coordinates
-cv::Vec3d vc::CartesianToBarycentric(
+auto vc::CartesianToBarycentric(
     const cv::Vec3d& pt,
     const cv::Vec3d& triA,
     const cv::Vec3d& triB,
-    const cv::Vec3d& triC)
+    const cv::Vec3d& triC) -> cv::Vec3d
 {
     auto v0 = triB - triA;
     auto v1 = triC - triA;
@@ -32,16 +32,16 @@ cv::Vec3d vc::CartesianToBarycentric(
     return output;
 }
 
-cv::Vec3d vc::BarycentricToCartesian(
+auto vc::BarycentricToCartesian(
     const cv::Vec3d& pt,
     const cv::Vec3d& triA,
     const cv::Vec3d& triB,
-    const cv::Vec3d& triC)
+    const cv::Vec3d& triC) -> cv::Vec3d
 {
     return pt[0] * triA + pt[1] * triB + pt[2] * triC;
 }
 
-bool vc::BarycentricPointIsInTriangle(const cv::Vec3d& pt)
+auto vc::BarycentricPointIsInTriangle(const cv::Vec3d& pt) -> bool
 {
     return (
         (pt[0] > 0.0 || AlmostEqual(pt[0], 0.0)) &&
@@ -60,11 +60,11 @@ auto vc::BarycentricNormalInterpolation(
         uvw[0] * nA + uvw[1] * nB + (1. - uvw[0] - uvw[1]) * nC);
 }
 
-bool vc::CartesianPointIsInTriangle(
+auto vc::CartesianPointIsInTriangle(
     const cv::Vec3d& pt,
     const cv::Vec3d& triA,
     const cv::Vec3d& triB,
-    const cv::Vec3d& triC)
+    const cv::Vec3d& triC) -> bool
 {
     auto bPt = CartesianToBarycentric(pt, triA, triB, triC);
     return BarycentricPointIsInTriangle(bPt);

--- a/core/src/ColorMaps.cpp
+++ b/core/src/ColorMaps.cpp
@@ -12,12 +12,12 @@
 using namespace volcart;
 namespace vc = volcart;
 
-static cv::Mat GetMagmaMat();
-static cv::Mat GetInfernoMat();
-static cv::Mat GetPlasmaMat();
-static cv::Mat GetViridisMat();
-static cv::Mat GetPhaseMat();
-static cv::Mat GetBWRMat();
+static auto GetMagmaMat() -> cv::Mat;
+static auto GetInfernoMat() -> cv::Mat;
+static auto GetPlasmaMat() -> cv::Mat;
+static auto GetViridisMat() -> cv::Mat;
+static auto GetPhaseMat() -> cv::Mat;
+static auto GetBWRMat() -> cv::Mat;
 
 static const std::unordered_map<ColorMap, std::string> CM_TO_STR{
     {ColorMap::Magma, "Magma"},   {ColorMap::Inferno, "Inferno"},
@@ -29,7 +29,7 @@ static const std::unordered_map<std::string, ColorMap> STR_TO_CM{
     {"plasma", ColorMap::Plasma}, {"viridis", ColorMap::Viridis},
     {"phase", ColorMap::Phase},   {"bwr", ColorMap::BWR}};
 
-cv::Mat vc::GetColorMapLUT(ColorMap cm, std::size_t bins)
+auto vc::GetColorMapLUT(ColorMap cm, std::size_t bins) -> cv::Mat
 {
     cv::Mat lut;
     switch (cm) {
@@ -62,14 +62,17 @@ cv::Mat vc::GetColorMapLUT(ColorMap cm, std::size_t bins)
     return lut;
 }
 
-cv::Mat vc::GetColorMapLUT(const std::string& name, std::size_t bins)
+auto vc::GetColorMapLUT(const std::string& name, std::size_t bins) -> cv::Mat
 {
     return GetColorMapLUT(ColorMapFromString(name), bins);
 }
 
-std::string vc::ColorMapToString(ColorMap cm) { return CM_TO_STR.at(cm); }
+auto vc::ColorMapToString(ColorMap cm) -> std::string
+{
+    return CM_TO_STR.at(cm);
+}
 
-ColorMap vc::ColorMapFromString(const std::string& str)
+auto vc::ColorMapFromString(const std::string& str) -> ColorMap
 {
     return STR_TO_CM.at(to_lower_copy(str));
 }
@@ -529,7 +532,7 @@ constexpr std::array<float, 3 * 3> PHASE_DATA = {
 constexpr std::array<float, 3 * 3> BWR_DATA = {1.F,   0.F, 0.F, 0.929F, 0.914F,
                                                0.91F, 0.F, 0.F, 1.F};
 
-cv::Mat GetMagmaMat()
+auto GetMagmaMat() -> cv::Mat
 {
     cv::Mat mat(1, 256, CV_32FC3);
     std::memcpy(
@@ -538,7 +541,7 @@ cv::Mat GetMagmaMat()
     return mat;
 }
 
-cv::Mat GetInfernoMat()
+auto GetInfernoMat() -> cv::Mat
 {
     cv::Mat mat(1, 256, CV_32FC3);
     std::memcpy(
@@ -547,7 +550,7 @@ cv::Mat GetInfernoMat()
     return mat;
 }
 
-cv::Mat GetPlasmaMat()
+auto GetPlasmaMat() -> cv::Mat
 {
     cv::Mat mat(1, 256, CV_32FC3);
     std::memcpy(
@@ -556,7 +559,7 @@ cv::Mat GetPlasmaMat()
     return mat;
 }
 
-cv::Mat GetViridisMat()
+auto GetViridisMat() -> cv::Mat
 {
     cv::Mat mat(1, 256, CV_32FC3);
     std::memcpy(
@@ -565,7 +568,7 @@ cv::Mat GetViridisMat()
     return mat;
 }
 
-cv::Mat GetPhaseMat()
+auto GetPhaseMat() -> cv::Mat
 {
     cv::Mat mat(1, 3, CV_32FC3);
     std::memcpy(
@@ -573,7 +576,7 @@ cv::Mat GetPhaseMat()
     return mat;
 }
 
-cv::Mat GetBWRMat()
+auto GetBWRMat() -> cv::Mat
 {
     cv::Mat mat(1, 3, CV_32FC3);
     std::memcpy(mat.data, BWR_DATA.begin(), BWR_DATA.size() * sizeof(float));

--- a/core/src/CuboidGenerator.cpp
+++ b/core/src/CuboidGenerator.cpp
@@ -8,10 +8,10 @@ static const std::vector<cv::Vec3d> BASIS_VECTORS = {
 
 using namespace volcart;
 
-Neighborhood CuboidGenerator::compute(
+auto CuboidGenerator::compute(
     const Volume::Pointer& v,
     const cv::Vec3d& pt,
-    const std::vector<cv::Vec3d>& axes)
+    const std::vector<cv::Vec3d>& axes) -> Neighborhood
 {
     // Auto-generate missing axes
     auto bases = axes;
@@ -79,7 +79,7 @@ Neighborhood CuboidGenerator::compute(
     return output;
 }
 
-Neighborhood::Extent CuboidGenerator::extents() const
+auto CuboidGenerator::extents() const -> Neighborhood::Extent
 {
     auto radius =
         (direction_ != Direction::Bidirectional) ? radius_[0] / 2 : radius_[0];

--- a/core/src/FormatStrToRegexStr.cpp
+++ b/core/src/FormatStrToRegexStr.cpp
@@ -2,7 +2,7 @@
 
 #include <regex>
 
-std::string volcart::FormatStrToRegexStr(const std::string& s)
+auto volcart::FormatStrToRegexStr(const std::string& s) -> std::string
 {
     std::string result;
 

--- a/core/src/LineGenerator.cpp
+++ b/core/src/LineGenerator.cpp
@@ -6,10 +6,10 @@
 
 using namespace volcart;
 
-Neighborhood LineGenerator::compute(
+auto LineGenerator::compute(
     const Volume::Pointer& v,
     const cv::Vec3d& pt,
-    const std::vector<cv::Vec3d>& axes)
+    const std::vector<cv::Vec3d>& axes) -> Neighborhood
 {
     // If we don't have enough axes by this point, we're doing it wrong
     if (axes.empty()) {
@@ -58,7 +58,7 @@ Neighborhood LineGenerator::compute(
     return n;
 }
 
-Neighborhood::Extent LineGenerator::extents() const
+auto LineGenerator::extents() const -> Neighborhood::Extent
 {
     auto radius =
         (direction_ != Direction::Bidirectional) ? radius_[0] / 2 : radius_[0];

--- a/core/src/MemorySizeStringParser.cpp
+++ b/core/src/MemorySizeStringParser.cpp
@@ -9,9 +9,9 @@ static constexpr std::size_t BYTES_PER_MB = BYTES_PER_KB * 1024;
 static constexpr std::size_t BYTES_PER_GB = BYTES_PER_MB * 1024;
 static constexpr std::size_t BYTES_PER_TB = BYTES_PER_GB * 1024;
 
-std::string to_string(const float val, const int n = 5);
+auto to_string(const float val, const int n = 5) -> std::string;
 
-std::size_t volcart::MemorySizeStringParser(const std::string& s)
+auto volcart::MemorySizeStringParser(const std::string& s) -> std::size_t
 {
     // Regex patterns. Stored as string for easy concatenation.
     std::string numRE{"^[0-9]+"};
@@ -58,8 +58,9 @@ std::size_t volcart::MemorySizeStringParser(const std::string& s)
     }
 }
 
-std::string volcart::BytesToMemorySizeString(
+auto volcart::BytesToMemorySizeString(
     std::size_t bytes, const std::string& suffix, MemoryStringFormat fmt)
+    -> std::string
 {
     // Return value / multiplier
     // TB
@@ -107,7 +108,7 @@ std::string volcart::BytesToMemorySizeString(
     }
 }
 
-std::string to_string(const float val, const int n)
+auto to_string(const float val, const int n) -> std::string
 {
     std::ostringstream out;
     out.precision(n);

--- a/core/src/MeshMath.cpp
+++ b/core/src/MeshMath.cpp
@@ -5,7 +5,7 @@
 namespace volcart::meshmath
 {
 
-double SurfaceArea(const ITKMesh::Pointer& mesh)
+auto SurfaceArea(const ITKMesh::Pointer& mesh) -> double
 {
     if(mesh == nullptr) {
         throw std::runtime_error("Failed to calculate surface area. Mesh is nullptr.");

--- a/core/src/Metadata.cpp
+++ b/core/src/Metadata.cpp
@@ -32,7 +32,7 @@ void Metadata::save(const fs::path& path)
     std::ofstream jsonFile(path.string(), std::ofstream::out);
 
     // try to push into the json file
-    jsonFile << json_ << std::endl;
+    jsonFile << json_ << '\n';
     if (jsonFile.fail()) {
         auto msg = "could not write json file '" + path.string() + "'";
         throw std::ifstream::failure(msg);

--- a/core/src/OBJReader.cpp
+++ b/core/src/OBJReader.cpp
@@ -197,7 +197,7 @@ void OBJReader::parse_mtllib_(const std::vector<std::string>& strs)
     ifs.close();
 }
 
-OBJReader::RefType OBJReader::classify_vertref_(const std::string& ref)
+auto OBJReader::classify_vertref_(const std::string& ref) -> OBJReader::RefType
 {
     const char delimiter = '/';
     auto slashCount = std::count(ref.begin(), ref.end(), delimiter);

--- a/core/src/PLYReader.cpp
+++ b/core/src/PLYReader.cpp
@@ -10,7 +10,7 @@ using namespace volcart;
 using namespace volcart::io;
 namespace fs = volcart::filesystem;
 
-ITKMesh::Pointer PLYReader::read()
+auto PLYReader::read() -> ITKMesh::Pointer
 {
     if (inputPath_.empty() || !fs::exists(inputPath_)) {
         auto msg = "File not provided or does not exist.";

--- a/core/src/PLYWriter.cpp
+++ b/core/src/PLYWriter.cpp
@@ -63,36 +63,35 @@ auto PLYWriter::write_header_() -> int
         return EXIT_FAILURE;
     }
 
-    outputMesh_ << "ply" << std::endl;
-    outputMesh_ << "format ascii 1.0" << std::endl;
-    outputMesh_ << "comment VC PLY Exporter v1.0" << std::endl;
+    outputMesh_ << "ply" << '\n';
+    outputMesh_ << "format ascii 1.0" << '\n';
+    outputMesh_ << "comment VC PLY Exporter v1.0" << '\n';
 
     // Vertex Info for Header
-    outputMesh_ << "element vertex " << mesh_->GetNumberOfPoints() << std::endl;
-    outputMesh_ << "property float x" << std::endl;
-    outputMesh_ << "property float y" << std::endl;
-    outputMesh_ << "property float z" << std::endl;
-    outputMesh_ << "property float nx" << std::endl;
-    outputMesh_ << "property float ny" << std::endl;
-    outputMesh_ << "property float nz" << std::endl;
+    outputMesh_ << "element vertex " << mesh_->GetNumberOfPoints() << '\n';
+    outputMesh_ << "property float x" << '\n';
+    outputMesh_ << "property float y" << '\n';
+    outputMesh_ << "property float z" << '\n';
+    outputMesh_ << "property float nx" << '\n';
+    outputMesh_ << "property float ny" << '\n';
+    outputMesh_ << "property float nz" << '\n';
 
     // Color info for vertices
     if ((not texture_.empty() and uvMap_ and not uvMap_->empty()) or
         not vcolors_.empty()) {
-        outputMesh_ << "property uchar red" << std::endl;
-        outputMesh_ << "property uchar green" << std::endl;
-        outputMesh_ << "property uchar blue" << std::endl;
+        outputMesh_ << "property uchar red" << '\n';
+        outputMesh_ << "property uchar green" << '\n';
+        outputMesh_ << "property uchar blue" << '\n';
     }
 
     // Face Info for Header
     if (mesh_->GetNumberOfCells() != 0) {
-        outputMesh_ << "element face " << mesh_->GetNumberOfCells()
-                    << std::endl;
-        outputMesh_ << "property list uchar int vertex_indices" << std::endl;
+        outputMesh_ << "element face " << mesh_->GetNumberOfCells() << '\n';
+        outputMesh_ << "property list uchar int vertex_indices" << '\n';
     }
 
     // End header
-    outputMesh_ << "end_header" << std::endl;
+    outputMesh_ << "end_header" << '\n';
 
     return EXIT_SUCCESS;
 }
@@ -136,7 +135,7 @@ auto PLYWriter::write_vertices_() -> int
             outputMesh_ << " " << i << " " << i << " " << i;
         }
 
-        outputMesh_ << std::endl;
+        outputMesh_ << '\n';
     }
 
     return EXIT_SUCCESS;
@@ -161,7 +160,7 @@ auto PLYWriter::write_faces_() -> int
              point != cell.Value()->PointIdsEnd(); ++point) {
             outputMesh_ << " " << *point;
         }
-        outputMesh_ << std::endl;
+        outputMesh_ << '\n';
     }
 
     return EXIT_SUCCESS;

--- a/core/src/PlaneLandmark.cpp
+++ b/core/src/PlaneLandmark.cpp
@@ -19,17 +19,17 @@ PlaneLandmark::PlaneLandmark(
     update_meta_();
 }
 
-PlaneLandmark::Pointer PlaneLandmark::New(
-    const Identifier& uuid, const std::string& name)
+auto PlaneLandmark::New(const Identifier& uuid, const std::string& name)
+    -> PlaneLandmark::Pointer
 {
     return std::make_shared<PlaneLandmark>(uuid, name);
 }
 
-PlaneLandmark::Pointer PlaneLandmark::New(
+auto PlaneLandmark::New(
     const Identifier& uuid,
     const std::string& name,
     const Point& center,
-    const Point& normal)
+    const Point& normal) -> PlaneLandmark::Pointer
 {
     return std::make_shared<PlaneLandmark>(uuid, name, center, normal);
 }
@@ -62,9 +62,15 @@ void PlaneLandmark::setNormal(const Point& values)
     update_meta_();
 }
 
-PlaneLandmark::Point PlaneLandmark::getCenter() const { return center_; }
+auto PlaneLandmark::getCenter() const -> PlaneLandmark::Point
+{
+    return center_;
+}
 
-PlaneLandmark::Point PlaneLandmark::getNormal() const { return normal_; }
+auto PlaneLandmark::getNormal() const -> PlaneLandmark::Point
+{
+    return normal_;
+}
 
 void PlaneLandmark::update_meta_()
 {

--- a/core/src/PointLandmark.cpp
+++ b/core/src/PointLandmark.cpp
@@ -16,14 +16,15 @@ PointLandmark::PointLandmark(
     update_meta_();
 }
 
-PointLandmark::Pointer PointLandmark::New(
-    const Identifier& uuid, const std::string& name)
+auto PointLandmark::New(const Identifier& uuid, const std::string& name)
+    -> PointLandmark::Pointer
 {
     return std::make_shared<PointLandmark>(uuid, name);
 }
 
-PointLandmark::Pointer PointLandmark::New(
+auto PointLandmark::New(
     const Identifier& uuid, const std::string& name, const cv::Vec3d& position)
+    -> PointLandmark::Pointer
 {
     return std::make_shared<PointLandmark>(uuid, name, position);
 }
@@ -42,6 +43,9 @@ void PointLandmark::setPosition(double x, double y, double z)
     update_meta_();
 }
 
-PointLandmark::Point PointLandmark::getPosition() const { return position_; }
+auto PointLandmark::getPosition() const -> PointLandmark::Point
+{
+    return position_;
+}
 
 void PointLandmark::update_meta_() { metadata_.set("position", position_); }

--- a/core/src/PolylineLandmark.cpp
+++ b/core/src/PolylineLandmark.cpp
@@ -17,14 +17,15 @@ PolylineLandmark::PolylineLandmark(
     update_meta_();
 }
 
-PolylineLandmark::Pointer PolylineLandmark::New(
-    const Identifier& uuid, const std::string& name)
+auto PolylineLandmark::New(const Identifier& uuid, const std::string& name)
+    -> PolylineLandmark::Pointer
 {
     return std::make_shared<PolylineLandmark>(uuid, name);
 }
 
-PolylineLandmark::Pointer PolylineLandmark::New(
+auto PolylineLandmark::New(
     const Identifier& uuid, const std::string& name, const Polyline& poly)
+    -> PolylineLandmark::Pointer
 {
     return std::make_shared<PolylineLandmark>(uuid, name, poly);
 }
@@ -35,7 +36,7 @@ void PolylineLandmark::setPolyline(Polyline p)
     update_meta_();
 }
 
-PolylineLandmark::Polyline PolylineLandmark::getPolyline() const
+auto PolylineLandmark::getPolyline() const -> PolylineLandmark::Polyline
 {
     return poly_;
 }

--- a/core/src/Reslice.cpp
+++ b/core/src/Reslice.cpp
@@ -6,7 +6,7 @@
 
 using namespace volcart;
 
-cv::Mat Reslice::draw() const
+auto Reslice::draw() const -> cv::Mat
 {
     auto debug = sliceData_.clone();
 

--- a/core/src/Segmentation.cpp
+++ b/core/src/Segmentation.cpp
@@ -28,14 +28,14 @@ Segmentation::Segmentation(fs::path path, Identifier uuid, std::string name)
 }
 
 // Load a Segmentation from disk, return a pointer
-Segmentation::Pointer Segmentation::New(fs::path path)
+auto Segmentation::New(fs::path path) -> Segmentation::Pointer
 {
     return std::make_shared<Segmentation>(path);
 }
 
 // Make a new segmentation on disk, return a pointer
-Segmentation::Pointer Segmentation::New(
-    fs::path path, std::string uuid, std::string name)
+auto Segmentation::New(fs::path path, std::string uuid, std::string name)
+    -> Segmentation::Pointer
 {
     return std::make_shared<Segmentation>(path, uuid, name);
 }
@@ -55,7 +55,7 @@ void Segmentation::setPointSet(const PointSet& ps)
 }
 
 // Load the PointSet from disk
-Segmentation::PointSet Segmentation::getPointSet() const
+auto Segmentation::getPointSet() const -> Segmentation::PointSet
 {
     // Make sure there's an associated pointset file
     if (metadata_.get<std::string>("vcps").empty()) {

--- a/core/src/ShapePrimitive.cpp
+++ b/core/src/ShapePrimitive.cpp
@@ -12,7 +12,7 @@ ShapePrimitive::ShapePrimitive()
 
 ///// Type Conversions /////
 // return an itk mesh
-ITKMesh::Pointer ShapePrimitive::itkMesh()
+auto ShapePrimitive::itkMesh() -> ITKMesh::Pointer
 {
     auto output = ITKMesh::New();
 
@@ -46,7 +46,7 @@ ITKMesh::Pointer ShapePrimitive::itkMesh()
 
 // initialize a vtk mesh //
 
-vtkSmartPointer<vtkPolyData> ShapePrimitive::vtkMesh()
+auto ShapePrimitive::vtkMesh() -> vtkSmartPointer<vtkPolyData>
 {
 
     // construct new pointer to output mesh
@@ -89,7 +89,7 @@ vtkSmartPointer<vtkPolyData> ShapePrimitive::vtkMesh()
 }
 
 // Return point set (unordered)
-volcart::PointSet<cv::Vec3d> ShapePrimitive::unorderedPoints()
+auto ShapePrimitive::unorderedPoints() -> volcart::PointSet<cv::Vec3d>
 {
     volcart::PointSet<cv::Vec3d> output;
 
@@ -101,7 +101,7 @@ volcart::PointSet<cv::Vec3d> ShapePrimitive::unorderedPoints()
 }
 
 // Return point set + normals (unordered)
-volcart::PointSet<cv::Vec6d> ShapePrimitive::unorderedPointNormal()
+auto ShapePrimitive::unorderedPointNormal() -> volcart::PointSet<cv::Vec6d>
 {
     volcart::PointSet<cv::Vec6d> output;
     for (auto p : points_) {
@@ -111,7 +111,7 @@ volcart::PointSet<cv::Vec6d> ShapePrimitive::unorderedPointNormal()
 }
 
 // Return point set (ordered)
-volcart::OrderedPointSet<cv::Vec3d> ShapePrimitive::orderedPoints()
+auto ShapePrimitive::orderedPoints() -> volcart::OrderedPointSet<cv::Vec3d>
 {
     if (!ordered_) {
         throw std::runtime_error("Shape vertices not ordered");
@@ -137,7 +137,7 @@ volcart::OrderedPointSet<cv::Vec3d> ShapePrimitive::orderedPoints()
 }
 
 // Return point set + normals (ordered)
-volcart::OrderedPointSet<cv::Vec6d> ShapePrimitive::orderedPointNormal()
+auto ShapePrimitive::orderedPointNormal() -> volcart::OrderedPointSet<cv::Vec6d>
 {
     if (!ordered_) {
         throw std::runtime_error("Shape vertices not ordered");

--- a/core/src/SkyscanMetadataIO.cpp
+++ b/core/src/SkyscanMetadataIO.cpp
@@ -11,7 +11,7 @@
 using namespace volcart;
 
 // Read and return map of metadata values
-volcart::Metadata SkyscanMetadataIO::read()
+auto SkyscanMetadataIO::read() -> volcart::Metadata
 {
     parse_();
     return metadata_;
@@ -183,7 +183,7 @@ void SkyscanMetadataIO::parse_()
     ifs.close();
 }
 
-std::string SkyscanMetadataIO::getSliceRegexString()
+auto SkyscanMetadataIO::getSliceRegexString() -> std::string
 {
     // Get components
     auto prefix = metadata_.get<std::string>("sliceImgPrefix");

--- a/core/src/Sphere.cpp
+++ b/core/src/Sphere.cpp
@@ -86,7 +86,7 @@ Sphere::Sphere(float /*radius*/, int recursion)
     }
 }
 
-int Sphere::midpoint_(int p1, int p2)
+auto Sphere::midpoint_(int p1, int p2) -> int
 {
     // Generate unique id
     bool firstIsSmaller = p1 < p2;

--- a/core/src/StructureTensor.cpp
+++ b/core/src/StructureTensor.cpp
@@ -9,18 +9,20 @@ using namespace volcart;
 /** @enum Axis labels */
 enum class Axis { X, Y };
 
-StructureTensor Tensorize(cv::Vec3d gradient);
-Tensor3D<cv::Vec3d> VolumeGradient(const Tensor3D<double>& v, int kernelSize);
-cv::Mat_<double> Gradient(const cv::Mat_<double>& input, Axis axis, int ksize);
-std::unique_ptr<double[]> MakeUniformGaussianField(int radius);
+auto Tensorize(cv::Vec3d gradient) -> StructureTensor;
+auto VolumeGradient(const Tensor3D<double>& v, int kernelSize)
+    -> Tensor3D<cv::Vec3d>;
+auto Gradient(const cv::Mat_<double>& input, Axis axis, int ksize)
+    -> cv::Mat_<double>;
+auto MakeUniformGaussianField(int radius) -> std::unique_ptr<double[]>;
 
-StructureTensor volcart::ComputeVoxelStructureTensor(
+auto volcart::ComputeVoxelStructureTensor(
     const Volume::Pointer& volume,
     int vx,
     int vy,
     int vz,
     int radius,
-    int kernelSize)
+    int kernelSize) -> StructureTensor
 {
     if (kernelSize < 3) {
         throw std::invalid_argument("gradient kernel size must be at least 3");
@@ -55,23 +57,23 @@ StructureTensor volcart::ComputeVoxelStructureTensor(
     return StructureTensor{matSum};
 }
 
-StructureTensor volcart::ComputeVoxelStructureTensor(
+auto volcart::ComputeVoxelStructureTensor(
     const Volume::Pointer& volume,
     const cv::Vec3i& index,
     int radius,
-    int kernelSize)
+    int kernelSize) -> StructureTensor
 {
     return ComputeVoxelStructureTensor(
         volume, index(0), index(1), index(2), radius, kernelSize);
 }
 
-StructureTensor volcart::ComputeSubvoxelStructureTensor(
+auto volcart::ComputeSubvoxelStructureTensor(
     const Volume::Pointer& volume,
     double vx,
     double vy,
     double vz,
     int radius,
-    int kernelSize)
+    int kernelSize) -> StructureTensor
 {
     if (kernelSize < 3) {
         throw std::invalid_argument("gradient kernel size must be at least 3");
@@ -101,23 +103,23 @@ StructureTensor volcart::ComputeSubvoxelStructureTensor(
     return StructureTensor{matSum};
 }
 
-StructureTensor volcart::ComputeSubvoxelStructureTensor(
+auto volcart::ComputeSubvoxelStructureTensor(
     const Volume::Pointer& volume,
     const cv::Vec3d& index,
     int radius,
-    int kernelSize)
+    int kernelSize) -> StructureTensor
 {
     return ComputeSubvoxelStructureTensor(
         volume, index(0), index(1), index(2), radius, kernelSize);
 }
 
-EigenPairs volcart::ComputeVoxelEigenPairs(
+auto volcart::ComputeVoxelEigenPairs(
     const Volume::Pointer& volume,
     int x,
     int y,
     int z,
     int radius,
-    int kernelSize)
+    int kernelSize) -> EigenPairs
 {
     auto st = ComputeVoxelStructureTensor(volume, x, y, z, radius, kernelSize);
     cv::Vec3d eigenValues;
@@ -136,23 +138,23 @@ EigenPairs volcart::ComputeVoxelEigenPairs(
     };
 }
 
-EigenPairs volcart::ComputeVoxelEigenPairs(
+auto volcart::ComputeVoxelEigenPairs(
     const Volume::Pointer& volume,
     const cv::Vec3i& index,
     int radius,
-    int kernelSize)
+    int kernelSize) -> EigenPairs
 {
     return ComputeVoxelEigenPairs(
         volume, index(0), index(1), index(2), radius, kernelSize);
 }
 
-EigenPairs volcart::ComputeSubvoxelEigenPairs(
+auto volcart::ComputeSubvoxelEigenPairs(
     const Volume::Pointer& volume,
     double x,
     double y,
     double z,
     int radius,
-    int kernelSize)
+    int kernelSize) -> EigenPairs
 {
     auto st =
         ComputeSubvoxelStructureTensor(volume, x, y, z, radius, kernelSize);
@@ -172,17 +174,17 @@ EigenPairs volcart::ComputeSubvoxelEigenPairs(
     };
 }
 
-EigenPairs volcart::ComputeSubvoxelEigenPairs(
+auto volcart::ComputeSubvoxelEigenPairs(
     const Volume::Pointer& volume,
     const cv::Vec3d& index,
     int radius,
-    int kernelSize)
+    int kernelSize) -> EigenPairs
 {
     return ComputeSubvoxelEigenPairs(
         volume, index(0), index(1), index(2), radius, kernelSize);
 }
 
-StructureTensor Tensorize(cv::Vec3d gradient)
+auto Tensorize(cv::Vec3d gradient) -> StructureTensor
 {
     double ix = gradient(0);
     double iy = gradient(1);
@@ -194,7 +196,8 @@ StructureTensor Tensorize(cv::Vec3d gradient)
     // clang-format on
 }
 
-Tensor3D<cv::Vec3d> VolumeGradient(const Tensor3D<double>& v, int kernelSize)
+auto VolumeGradient(const Tensor3D<double>& v, int kernelSize)
+    -> Tensor3D<cv::Vec3d>
 {
     // Limitation of OpenCV: Kernel size must be 1, 3, 5, or 7
     assert(
@@ -232,7 +235,8 @@ Tensor3D<cv::Vec3d> VolumeGradient(const Tensor3D<double>& v, int kernelSize)
 // Helper function to calculate gradient using best choice for given kernel
 // size. If the kernel size is 3, uses the Scharr() operator to calculate the
 // gradient which is more accurate than 3x3 Sobel operator
-cv::Mat_<double> Gradient(const cv::Mat_<double>& input, Axis axis, int ksize)
+auto Gradient(const cv::Mat_<double>& input, Axis axis, int ksize)
+    -> cv::Mat_<double>
 {
     // OpenCV params for gradients
     // XXX Revisit this and see if changing these makes a big difference
@@ -268,7 +272,7 @@ cv::Mat_<double> Gradient(const cv::Mat_<double>& input, Axis axis, int ksize)
     return grad;
 }
 
-std::unique_ptr<double[]> MakeUniformGaussianField(int radius)
+auto MakeUniformGaussianField(int radius) -> std::unique_ptr<double[]>
 {
     auto sideLength = 2 * static_cast<std::size_t>(radius) + 1;
     auto fieldSize = sideLength * sideLength * sideLength;

--- a/core/src/TIFFIO.cpp
+++ b/core/src/TIFFIO.cpp
@@ -107,7 +107,7 @@ auto tio::ReadTIFF(const volcart::filesystem::path& path) -> cv::Mat
             std::memcpy(img.ptr(row), &buffer[0], bufferSize);
         }
     } else if (config == PLANARCONFIG_SEPARATE) {
-        std::runtime_error(
+        throw std::runtime_error(
             "Unsupported TIFF planar configuration: PLANARCONFIG_SEPARATE");
     }
 

--- a/core/src/UVMapIO.cpp
+++ b/core/src/UVMapIO.cpp
@@ -25,14 +25,14 @@ void vio::WriteUVMap(const fs::path& path, const UVMap& uvMap)
 
     // Header
     std::stringstream ss;
-    ss << "filetype: uvmap" << std::endl;
-    ss << "version: 1" << std::endl;
-    ss << "type: per-vertex" << std::endl;
-    ss << "size: " << uvMap.size() << std::endl;
-    ss << "width: " << uvMap.ratio().width << std::endl;
-    ss << "height: " << uvMap.ratio().height << std::endl;
-    ss << "origin: " << static_cast<int>(uvMap.origin()) << std::endl;
-    ss << "<>" << std::endl;
+    ss << "filetype: uvmap" << '\n';
+    ss << "version: 1" << '\n';
+    ss << "type: per-vertex" << '\n';
+    ss << "size: " << uvMap.size() << '\n';
+    ss << "width: " << uvMap.ratio().width << '\n';
+    ss << "height: " << uvMap.ratio().height << '\n';
+    ss << "origin: " << static_cast<int>(uvMap.origin()) << '\n';
+    ss << "<>" << '\n';
     outfile << ss.rdbuf();
 
     // Write the mappings

--- a/core/src/VolumeLandmark.cpp
+++ b/core/src/VolumeLandmark.cpp
@@ -19,24 +19,24 @@ VolumeLandmark::VolumeLandmark(
     type_ = type;
 }
 
-VolumeLandmark::Identifier VolumeLandmark::id() const
+auto VolumeLandmark::id() const -> VolumeLandmark::Identifier
 {
     return metadata_.get<std::string>("uuid");
 }
 
-std::string VolumeLandmark::name() const
+auto VolumeLandmark::name() const -> std::string
 {
     return metadata_.get<std::string>("name");
 }
 
-Type VolumeLandmark::type() const { return type_; }
+auto VolumeLandmark::type() const -> Type { return type_; }
 
 void VolumeLandmark::Write(const fs::path& path, const Pointer& ldm)
 {
     ldm->metadata_.save(path);
 }
 
-VolumeLandmark::Pointer VolumeLandmark::Read(const fs::path& path)
+auto VolumeLandmark::Read(const fs::path& path) -> VolumeLandmark::Pointer
 {
     // Load metadata
     volcart::Metadata meta(path);

--- a/core/src/VolumeMask.cpp
+++ b/core/src/VolumeMask.cpp
@@ -34,14 +34,14 @@ void VolumeMask::setSubvolumeState(
     }
 }
 
-VolumeMask::State VolumeMask::getVoxelState(const cv::Vec3i& xyz)
+auto VolumeMask::getVoxelState(const cv::Vec3i& xyz) -> VolumeMask::State
 {
     return static_cast<State>(
         states_.coeffRef(xyz[2] * sliceHeight_ + xyz[1], xyz[0]));
 }
 
-VolumeMask::Subvolume VolumeMask::getSubvolumeState(
-    const cv::Vec3i& origin, const cv::Vec3i& dims)
+auto VolumeMask::getSubvolumeState(
+    const cv::Vec3i& origin, const cv::Vec3i& dims) -> VolumeMask::Subvolume
 {
     Subvolume result(3, dims[2], dims[1], dims[0]);
     int u, v;

--- a/core/test/SignalsTest.cpp
+++ b/core/test/SignalsTest.cpp
@@ -24,7 +24,7 @@ static void freeFnIntPtrSlot(int* i) { freeFnIntRefSlot(*i); }
 
 [[noreturn]] static void freeFnExit()
 {
-    std::cerr << "Success" << std::endl;
+    std::cerr << "Success" << '\n';
     std::exit(0);
 }
 
@@ -36,7 +36,7 @@ struct Receiver {
     void floatSlot(float f) { floatVal = f; }
     [[noreturn]] void exitSlot()
     {
-        std::cerr << "Success" << std::endl;
+        std::cerr << "Success" << '\n';
         std::exit(intVal);
     }
 

--- a/examples/src/ABFExample.cpp
+++ b/examples/src/ABFExample.cpp
@@ -10,7 +10,7 @@
 #include "vc/core/shapes/Spiral.hpp"
 #include "vc/texturing/AngleBasedFlattening.hpp"
 
-int main()
+auto main() -> int
 {
     // Create the mesh writer
     volcart::io::OBJWriter mesh_writer;

--- a/examples/src/ITK2VTKExample.cpp
+++ b/examples/src/ITK2VTKExample.cpp
@@ -114,21 +114,21 @@ auto main() -> int
 
             // write header
             MeshOutputFileStream
-                << "ply" << std::endl
-                << "format ascii 1.0" << std::endl
+                << "ply" << '\n'
+                << "format ascii 1.0" << '\n'
                 << "comment Created by particle simulation "
                    "https://github.com/viscenter/registration-toolkit"
-                << std::endl
-                << "element vertex " << NumberOfVTKPoints << std::endl
-                << "property float x" << std::endl
-                << "property float y" << std::endl
-                << "property float z" << std::endl
-                << "property float nx" << std::endl
-                << "property float ny" << std::endl
-                << "property float nz" << std::endl
-                << "element face " << NumberOfVTKCells << std::endl
-                << "property list uchar int vertex_indices" << std::endl
-                << "end_header" << std::endl;
+                << '\n'
+                << "element vertex " << NumberOfVTKPoints << '\n'
+                << "property float x" << '\n'
+                << "property float y" << '\n'
+                << "property float z" << '\n'
+                << "property float nx" << '\n'
+                << "property float ny" << '\n'
+                << "property float nz" << '\n'
+                << "element face " << NumberOfVTKCells << '\n'
+                << "property list uchar int vertex_indices" << '\n'
+                << "end_header" << '\n';
 
             for (int point = 0; point < NumberOfVTKPoints; point++) {
 
@@ -147,7 +147,7 @@ auto main() -> int
                     << " "
                     << out_VTKPlaneMesh->GetPointData()->GetNormals()->GetTuple(
                            point)[2]
-                    << std::endl;
+                    << '\n';
             }
 
             for (vtkIdType c_id = 0; c_id < NumberOfVTKCells; c_id++) {
@@ -157,7 +157,7 @@ auto main() -> int
                 MeshOutputFileStream
                     << "3 " << out_VTKCell->GetPointIds()->GetId(0) << " "
                     << out_VTKCell->GetPointIds()->GetId(1) << " "
-                    << out_VTKCell->GetPointIds()->GetId(2) << std::endl;
+                    << out_VTKCell->GetPointIds()->GetId(2) << '\n';
             }
 
         }
@@ -172,21 +172,21 @@ auto main() -> int
 
             // write header
             MeshOutputFileStream
-                << "ply" << std::endl
-                << "format ascii 1.0" << std::endl
+                << "ply" << '\n'
+                << "format ascii 1.0" << '\n'
                 << "comment Created by particle simulation "
                    "https://github.com/viscenter/registration-toolkit"
-                << std::endl
-                << "element vertex " << NumberOfVTKPoints << std::endl
-                << "property float x" << std::endl
-                << "property float y" << std::endl
-                << "property float z" << std::endl
-                << "property float nx" << std::endl
-                << "property float ny" << std::endl
-                << "property float nz" << std::endl
-                << "element face " << NumberOfVTKCells << std::endl
-                << "property list uchar int vertex_indices" << std::endl
-                << "end_header" << std::endl;
+                << '\n'
+                << "element vertex " << NumberOfVTKPoints << '\n'
+                << "property float x" << '\n'
+                << "property float y" << '\n'
+                << "property float z" << '\n'
+                << "property float nx" << '\n'
+                << "property float ny" << '\n'
+                << "property float nz" << '\n'
+                << "element face " << NumberOfVTKCells << '\n'
+                << "property list uchar int vertex_indices" << '\n'
+                << "end_header" << '\n';
 
             for (int point = 0; point < NumberOfVTKPoints; point++) {
 
@@ -205,7 +205,7 @@ auto main() -> int
                     << " "
                     << out_VTKCubeMesh->GetPointData()->GetNormals()->GetTuple(
                            point)[2]
-                    << std::endl;
+                    << '\n';
             }
 
             for (vtkIdType c_id = 0; c_id < NumberOfVTKCells; c_id++) {
@@ -215,7 +215,7 @@ auto main() -> int
                 MeshOutputFileStream
                     << "3 " << out_VTKCell->GetPointIds()->GetId(0) << " "
                     << out_VTKCell->GetPointIds()->GetId(1) << " "
-                    << out_VTKCell->GetPointIds()->GetId(2) << std::endl;
+                    << out_VTKCell->GetPointIds()->GetId(2) << '\n';
             }
 
         }
@@ -230,21 +230,21 @@ auto main() -> int
 
             // write header
             MeshOutputFileStream
-                << "ply" << std::endl
-                << "format ascii 1.0" << std::endl
+                << "ply" << '\n'
+                << "format ascii 1.0" << '\n'
                 << "comment Created by particle simulation "
                    "https://github.com/viscenter/registration-toolkit"
-                << std::endl
-                << "element vertex " << NumberOfVTKPoints << std::endl
-                << "property float x" << std::endl
-                << "property float y" << std::endl
-                << "property float z" << std::endl
-                << "property float nx" << std::endl
-                << "property float ny" << std::endl
-                << "property float nz" << std::endl
-                << "element face " << NumberOfVTKCells << std::endl
-                << "property list uchar int vertex_indices" << std::endl
-                << "end_header" << std::endl;
+                << '\n'
+                << "element vertex " << NumberOfVTKPoints << '\n'
+                << "property float x" << '\n'
+                << "property float y" << '\n'
+                << "property float z" << '\n'
+                << "property float nx" << '\n'
+                << "property float ny" << '\n'
+                << "property float nz" << '\n'
+                << "element face " << NumberOfVTKCells << '\n'
+                << "property list uchar int vertex_indices" << '\n'
+                << "end_header" << '\n';
 
             for (int point = 0; point < NumberOfVTKPoints; point++) {
 
@@ -263,7 +263,7 @@ auto main() -> int
                     << " "
                     << out_VTKArchMesh->GetPointData()->GetNormals()->GetTuple(
                            point)[2]
-                    << std::endl;
+                    << '\n';
             }
 
             for (vtkIdType c_id = 0; c_id < NumberOfVTKCells; c_id++) {
@@ -273,7 +273,7 @@ auto main() -> int
                 MeshOutputFileStream
                     << "3 " << out_VTKCell->GetPointIds()->GetId(0) << " "
                     << out_VTKCell->GetPointIds()->GetId(1) << " "
-                    << out_VTKCell->GetPointIds()->GetId(2) << std::endl;
+                    << out_VTKCell->GetPointIds()->GetId(2) << '\n';
             }
 
         }
@@ -287,21 +287,21 @@ auto main() -> int
             MeshOutputFileStream.open("ITKSphereMeshConvertedToVTK.ply");
             // write header
             MeshOutputFileStream
-                << "ply" << std::endl
-                << "format ascii 1.0" << std::endl
+                << "ply" << '\n'
+                << "format ascii 1.0" << '\n'
                 << "comment Created by particle simulation "
                    "https://github.com/viscenter/registration-toolkit"
-                << std::endl
-                << "element vertex " << NumberOfVTKPoints << std::endl
-                << "property float x" << std::endl
-                << "property float y" << std::endl
-                << "property float z" << std::endl
-                << "property float nx" << std::endl
-                << "property float ny" << std::endl
-                << "property float nz" << std::endl
-                << "element face " << NumberOfVTKCells << std::endl
-                << "property list uchar int vertex_indices" << std::endl
-                << "end_header" << std::endl;
+                << '\n'
+                << "element vertex " << NumberOfVTKPoints << '\n'
+                << "property float x" << '\n'
+                << "property float y" << '\n'
+                << "property float z" << '\n'
+                << "property float nx" << '\n'
+                << "property float ny" << '\n'
+                << "property float nz" << '\n'
+                << "element face " << NumberOfVTKCells << '\n'
+                << "property list uchar int vertex_indices" << '\n'
+                << "end_header" << '\n';
 
             for (int point = 0; point < NumberOfVTKPoints; point++) {
 
@@ -322,7 +322,7 @@ auto main() -> int
                                      << out_VTKSphereMesh->GetPointData()
                                             ->GetNormals()
                                             ->GetTuple(point)[2]
-                                     << std::endl;
+                                     << '\n';
             }
 
             for (vtkIdType c_id = 0; c_id < NumberOfVTKCells; c_id++) {
@@ -332,7 +332,7 @@ auto main() -> int
                 MeshOutputFileStream
                     << "3 " << out_VTKCell->GetPointIds()->GetId(0) << " "
                     << out_VTKCell->GetPointIds()->GetId(1) << " "
-                    << out_VTKCell->GetPointIds()->GetId(2) << std::endl;
+                    << out_VTKCell->GetPointIds()->GetId(2) << '\n';
             }
 
         }
@@ -347,21 +347,21 @@ auto main() -> int
 
             // write header
             MeshOutputFileStream
-                << "ply" << std::endl
-                << "format ascii 1.0" << std::endl
+                << "ply" << '\n'
+                << "format ascii 1.0" << '\n'
                 << "comment Created by particle simulation "
                    "https://github.com/viscenter/registration-toolkit"
-                << std::endl
-                << "element vertex " << NumberOfVTKPoints << std::endl
-                << "property float x" << std::endl
-                << "property float y" << std::endl
-                << "property float z" << std::endl
-                << "property float nx" << std::endl
-                << "property float ny" << std::endl
-                << "property float nz" << std::endl
-                << "element face " << NumberOfVTKCells << std::endl
-                << "property list uchar int vertex_indices" << std::endl
-                << "end_header" << std::endl;
+                << '\n'
+                << "element vertex " << NumberOfVTKPoints << '\n'
+                << "property float x" << '\n'
+                << "property float y" << '\n'
+                << "property float z" << '\n'
+                << "property float nx" << '\n'
+                << "property float ny" << '\n'
+                << "property float nz" << '\n'
+                << "element face " << NumberOfVTKCells << '\n'
+                << "property list uchar int vertex_indices" << '\n'
+                << "end_header" << '\n';
 
             for (int point = 0; point < NumberOfVTKPoints; point++) {
 
@@ -380,7 +380,7 @@ auto main() -> int
                     << " "
                     << out_VTKConeMesh->GetPointData()->GetNormals()->GetTuple(
                            point)[2]
-                    << std::endl;
+                    << '\n';
             }
 
             for (vtkIdType c_id = 0; c_id < NumberOfVTKCells; c_id++) {
@@ -390,7 +390,7 @@ auto main() -> int
                 MeshOutputFileStream
                     << "3 " << out_VTKCell->GetPointIds()->GetId(0) << " "
                     << out_VTKCell->GetPointIds()->GetId(1) << " "
-                    << out_VTKCell->GetPointIds()->GetId(2) << std::endl;
+                    << out_VTKCell->GetPointIds()->GetId(2) << '\n';
             }
         }
 

--- a/examples/src/ITK2VTKExample.cpp
+++ b/examples/src/ITK2VTKExample.cpp
@@ -18,7 +18,7 @@
 
 void writePLYHeaderAndPoints(std::ostream& out, vtkPolyData* mesh);
 
-int main()
+auto main() -> int
 {
     // init shapes --> used by both conversion directions
     volcart::shapes::Plane Plane;

--- a/examples/src/OBJWriterExample.cpp
+++ b/examples/src/OBJWriterExample.cpp
@@ -7,7 +7,7 @@
 #include "vc/core/io/OBJWriter.hpp"
 #include "vc/core/shapes/Plane.hpp"
 
-int main()
+auto main() -> int
 {
     // init shapes
     volcart::shapes::Plane Plane;

--- a/examples/src/OrderedPointSetMesherExample.cpp
+++ b/examples/src/OrderedPointSetMesherExample.cpp
@@ -6,7 +6,7 @@
 
 using namespace volcart;
 
-int main()
+auto main() -> int
 {
     // Plane
     OrderedPointSet<cv::Vec3d> Plane(5);

--- a/examples/src/OrderedResamplingExample.cpp
+++ b/examples/src/OrderedResamplingExample.cpp
@@ -5,7 +5,7 @@
 #include "vc/core/shapes/Plane.hpp"
 #include "vc/meshing/OrderedResampling.hpp"
 
-int main()
+auto main() -> int
 {
     volcart::io::OBJWriter writer;
 

--- a/examples/src/ScaleMeshExample.cpp
+++ b/examples/src/ScaleMeshExample.cpp
@@ -13,7 +13,7 @@
 #include "vc/core/shapes/Sphere.hpp"
 #include "vc/meshing/ScaleMesh.hpp"
 
-int main()
+auto main() -> int
 {
 
     // init shapes

--- a/examples/src/SignalsExample.cpp
+++ b/examples/src/SignalsExample.cpp
@@ -16,7 +16,7 @@ inline void MultiParameter(int i, float f, const std::string& s)
 
 using namespace volcart;
 
-int main()
+auto main() -> int
 {
     // No parameter
     Signal<> event;

--- a/examples/src/SignalsExample.cpp
+++ b/examples/src/SignalsExample.cpp
@@ -3,15 +3,15 @@
 
 #include "vc/core/util/Signals.hpp"
 
-inline void NoParameter() { std::cout << "Hello, World!" << std::endl; }
+inline void NoParameter() { std::cout << "Hello, World!" << '\n'; }
 
-inline void SingleParameter(int i) { std::cout << i << std::endl; }
+inline void SingleParameter(int i) { std::cout << i << '\n'; }
 
-inline void FloatParameter(float f) { std::cout << f << std::endl; }
+inline void FloatParameter(float f) { std::cout << f << '\n'; }
 
 inline void MultiParameter(int i, float f, const std::string& s)
 {
-    std::cout << i << " " << f << " " << s << std::endl;
+    std::cout << i << " " << f << " " << s << '\n';
 }
 
 using namespace volcart;

--- a/examples/src/SmoothNormalsExample.cpp
+++ b/examples/src/SmoothNormalsExample.cpp
@@ -17,7 +17,7 @@
 #include "vc/core/shapes/Sphere.hpp"
 #include "vc/meshing/SmoothNormals.hpp"
 
-int main()
+auto main() -> int
 {
 
     // smoothing factor

--- a/graph/src/meshing.cpp
+++ b/graph/src/meshing.cpp
@@ -120,8 +120,8 @@ CalculateNumVertsNode::CalculateNumVertsNode()
     };
 }
 
-smgl::Metadata CalculateNumVertsNode::serialize_(
-    bool /*useCache*/, const fs::path& /*cacheDir*/)
+auto CalculateNumVertsNode::serialize_(
+    bool /*useCache*/, const fs::path& /*cacheDir*/) -> smgl::Metadata
 {
     return {
         {"density", density_},

--- a/meshing/src/ACVD.cpp
+++ b/meshing/src/ACVD.cpp
@@ -33,9 +33,9 @@ void ACVD::setQuadricsOptimizationLevel(std::size_t l)
     quadricsOptLevel_ = l;
 }
 
-ITKMesh::Pointer ACVD::getOutputMesh() const { return outputMesh_; }
+auto ACVD::getOutputMesh() const -> ITKMesh::Pointer { return outputMesh_; }
 
-ITKMesh::Pointer ACVD::compute()
+auto ACVD::compute() -> ITKMesh::Pointer
 {
     Logger()->info(
         "ACVD: Input: {} verts, {} faces", inputMesh_->GetNumberOfPoints(),

--- a/meshing/src/CalculateNormals.cpp
+++ b/meshing/src/CalculateNormals.cpp
@@ -15,7 +15,7 @@ CalculateNormals::CalculateNormals(const ITKMesh::Pointer& mesh)
 void CalculateNormals::setMesh(const ITKMesh::Pointer& mesh) { input_ = mesh; }
 
 ///// Processing /////
-ITKMesh::Pointer CalculateNormals::compute()
+auto CalculateNormals::compute() -> ITKMesh::Pointer
 {
     output_ = ITKMesh::New();
     DeepCopy(input_, output_);

--- a/meshing/src/OrderedPointSetMesher.cpp
+++ b/meshing/src/OrderedPointSetMesher.cpp
@@ -6,7 +6,7 @@
 
 using namespace volcart::meshing;
 
-volcart::ITKMesh::Pointer OrderedPointSetMesher::compute()
+auto OrderedPointSetMesher::compute() -> volcart::ITKMesh::Pointer
 {
     // Verify before computation
     if (input_.empty()) {

--- a/meshing/src/OrderedResampling.cpp
+++ b/meshing/src/OrderedResampling.cpp
@@ -18,7 +18,7 @@ void OrderedResampling::setMesh(
     inHeight_ = inHeight;
 }
 
-volcart::ITKMesh::Pointer OrderedResampling::getOutputMesh() const
+auto OrderedResampling::getOutputMesh() const -> volcart::ITKMesh::Pointer
 {
     if (output_.IsNull()) {
         Logger()->error("Output mesh is null");

--- a/meshing/src/ScaleMesh.cpp
+++ b/meshing/src/ScaleMesh.cpp
@@ -22,7 +22,8 @@ void ScaleMesh(
     }
 }
 
-ITKMesh::Pointer ScaleMesh(const ITKMesh::Pointer& input, double scaleFactor)
+auto ScaleMesh(const ITKMesh::Pointer& input, double scaleFactor)
+    -> ITKMesh::Pointer
 {
     auto output = ITKMesh::New();
     ScaleMesh(input, output, scaleFactor);

--- a/meshing/src/SmoothNormals.cpp
+++ b/meshing/src/SmoothNormals.cpp
@@ -13,7 +13,8 @@
 namespace volcart::meshing
 {
 
-ITKMesh::Pointer SmoothNormals(const ITKMesh::Pointer& input, double radius)
+auto SmoothNormals(const ITKMesh::Pointer& input, double radius)
+    -> ITKMesh::Pointer
 {
     // declare pointer to new Mesh object to be returned
     auto outputMesh = ITKMesh::New();

--- a/meshing/src/UVMapToITKMesh.cpp
+++ b/meshing/src/UVMapToITKMesh.cpp
@@ -9,7 +9,7 @@ void UVMapToITKMesh::setUVMap(UVMap::Pointer u) { uvMap_ = std::move(u); }
 
 void UVMapToITKMesh::setScaleToUVDimensions(bool b) { scaleMesh_ = b; }
 
-ITKMesh::Pointer UVMapToITKMesh::compute()
+auto UVMapToITKMesh::compute() -> ITKMesh::Pointer
 {
     // Setup the output mesh with the faces of the input mesh
     outputMesh_ = ITKMesh::New();

--- a/segmentation/include/vc/segmentation/stps/ForceChain.hpp
+++ b/segmentation/include/vc/segmentation/stps/ForceChain.hpp
@@ -39,10 +39,10 @@ public:
      * Throws `std::domain_error` if ForceChain size doesn't match the size of
      * this ForceChain.
      */
-    ForceChain& operator+=(const ForceChain& rhs);
+    auto operator+=(const ForceChain& rhs) -> ForceChain&;
 
     /** @brief Multiply each element of chain by a constant scale factor */
-    ForceChain& operator*=(const double& rhs);
+    auto operator*=(const double& rhs) -> ForceChain&;
 
     /** @brief Element access operator */
     auto operator[](std::size_t i) { return data_[i]; }
@@ -73,10 +73,10 @@ public:
     void push_back(const Force& val) { data_.push_back(val); }
 
     /** @brief Returns the number of elements in the chain */
-    std::size_t size() { return data_.size(); }
+    auto size() -> std::size_t { return data_.size(); }
 
     /** @copydoc size() */
-    std::size_t size() const { return data_.size(); }
+    auto size() const -> std::size_t { return data_.size(); }
 
     /** @brief Empties and resets the chain */
     void clear() { data_.clear(); }
@@ -94,9 +94,9 @@ private:
 };
 
 /** Free function operator for per-element ForceChain addition */
-ForceChain operator+(ForceChain lhs, const ForceChain& rhs);
+auto operator+(ForceChain lhs, const ForceChain& rhs) -> ForceChain;
 /** Free function operator for multiplying a ForceChain by a scalar */
-ForceChain operator*(ForceChain lhs, const double& rhs);
+auto operator*(ForceChain lhs, const double& rhs) -> ForceChain;
 /** @copydoc operator*(ForceChain, const double&) */
-ForceChain operator*(const double& rhs, ForceChain lhs);
+auto operator*(const double& rhs, ForceChain lhs) -> ForceChain;
 }  // namespace volcart::segmentation

--- a/segmentation/include/vc/segmentation/stps/ParticleChain.hpp
+++ b/segmentation/include/vc/segmentation/stps/ParticleChain.hpp
@@ -38,10 +38,10 @@ public:
      * Throws `std::domain_error` if ForceChain size doesn't match the size of
      * the ParticleChain.
      */
-    ParticleChain& operator+=(const ForceChain& rhs);
+    auto operator+=(const ForceChain& rhs) -> ParticleChain&;
 
     /** @brief Multiply each element of chain by a constant scale factor */
-    ParticleChain& operator*=(const double& rhs);
+    auto operator*=(const double& rhs) -> ParticleChain&;
 
     /** @brief Element access operator */
     auto operator[](std::size_t i) { return data_[i]; }
@@ -72,10 +72,10 @@ public:
     void push_back(const Particle& val) { data_.push_back(val); }
 
     /** @brief Returns the number of elements in the chain */
-    std::size_t size() { return data_.size(); }
+    auto size() -> std::size_t { return data_.size(); }
 
     /** @copydoc size() */
-    std::size_t size() const { return data_.size(); }
+    auto size() const -> std::size_t { return data_.size(); }
 
     /** @brief Empties and resets the chain */
     void clear() { data_.clear(); }
@@ -86,11 +86,11 @@ private:
 };
 
 /** Free function operator for ParticleChain and ForceChain addition */
-ParticleChain operator+(ParticleChain lhs, const ForceChain& rhs);
+auto operator+(ParticleChain lhs, const ForceChain& rhs) -> ParticleChain;
 /** @copydoc operator+(ParticleChain, const ForceChain&) */
-ParticleChain operator+(const ForceChain& rhs, ParticleChain lhs);
+auto operator+(const ForceChain& rhs, ParticleChain lhs) -> ParticleChain;
 /** Free function operator for multiplying a ParticleChain by a scalar */
-ParticleChain operator*(ParticleChain lhs, const double& rhs);
+auto operator*(ParticleChain lhs, const double& rhs) -> ParticleChain;
 /** @copydoc operator*(ParticleChain, const double&) */
-ParticleChain operator*(const double& rhs, ParticleChain lhs);
+auto operator*(const double& rhs, ParticleChain lhs) -> ParticleChain;
 }  // namespace volcart::segmentation

--- a/segmentation/src/Common.cpp
+++ b/segmentation/src/Common.cpp
@@ -2,8 +2,9 @@
 
 #include <cstddef>
 
-std::vector<double> volcart::segmentation::SquareDiff(
+auto volcart::segmentation::SquareDiff(
     const std::vector<Voxel>& v1, const std::vector<Voxel>& v2)
+    -> std::vector<double>
 {
     assert(v1.size() == v2.size() && "src and target must be the same size");
     std::vector<double> res(v1.size());
@@ -14,8 +15,8 @@ std::vector<double> volcart::segmentation::SquareDiff(
     return res;
 }
 
-double volcart::segmentation::SumSquareDiff(
-    const std::vector<double>& v1, const std::vector<double>& v2)
+auto volcart::segmentation::SumSquareDiff(
+    const std::vector<double>& v1, const std::vector<double>& v2) -> double
 {
     assert(v1.size() == v2.size() && "v1 and v2 must be the same size");
     double res = 0;

--- a/segmentation/src/ComputeVolumetricMask.cpp
+++ b/segmentation/src/ComputeVolumetricMask.cpp
@@ -30,7 +30,7 @@ void ComputeVolumetricMask::setMaxRadius(std::size_t radius)
     maxRadius_ = radius;
 }
 
-VolumetricMask::Pointer ComputeVolumetricMask::compute()
+auto ComputeVolumetricMask::compute() -> VolumetricMask::Pointer
 {
     // Setup the output
     mask_ = VolumetricMask::New();
@@ -114,9 +114,12 @@ void ComputeVolumetricMask::setPointSet(const PointSet& ps) { input_ = ps; }
 
 void ComputeVolumetricMask::setVolume(const Volume::Pointer& v) { vol_ = v; }
 
-VolumetricMask::Pointer ComputeVolumetricMask::getMask() const { return mask_; }
+auto ComputeVolumetricMask::getMask() const -> VolumetricMask::Pointer
+{
+    return mask_;
+}
 
-std::size_t ComputeVolumetricMask::progressIterations() const
+auto ComputeVolumetricMask::progressIterations() const -> std::size_t
 {
     if (input_.empty()) {
         return 0;

--- a/segmentation/src/EnergyMetrics.cpp
+++ b/segmentation/src/EnergyMetrics.cpp
@@ -10,8 +10,8 @@ using namespace volcart::segmentation;
 // Calculates the active contour internal energy. See:
 // https://en.wikipedia.org/wiki/Active_contour_model#Internal_energy
 // Note: k1 and k2 are constant for all particles in the curve
-double EnergyMetrics::ActiveContourInternal(
-    const FittedCurve& curve, double k1, double k2)
+auto EnergyMetrics::ActiveContourInternal(
+    const FittedCurve& curve, double k1, double k2) -> double
 {
     if (curve.size() <= 0) {
         return 0;
@@ -31,13 +31,13 @@ double EnergyMetrics::ActiveContourInternal(
 
 // Amalgamation of energy metrics used parameterized by their coefficients.
 // To disable a metric, simply set its coefficient to zero
-double EnergyMetrics::TotalEnergy(
+auto EnergyMetrics::TotalEnergy(
     const FittedCurve& curve,
     double alpha,
     double k1,
     double k2,
     double beta,
-    double delta)
+    double delta) -> double
 {
     auto intE = EnergyMetrics::ActiveContourInternal(curve, k1, k2);
     auto kE = EnergyMetrics::AbsCurvatureSum(curve);
@@ -46,7 +46,7 @@ double EnergyMetrics::TotalEnergy(
 }
 
 // Sum of the absolute value of the curvature from curve
-double EnergyMetrics::AbsCurvatureSum(const FittedCurve& curve)
+auto EnergyMetrics::AbsCurvatureSum(const FittedCurve& curve) -> double
 {
     if (curve.size() <= 0) {
         return 0;
@@ -65,8 +65,8 @@ double EnergyMetrics::AbsCurvatureSum(const FittedCurve& curve)
 
 // Determine arc length across a window of size 'windowSize' centered at
 // 'index'
-double EnergyMetrics::LocalWindowedArcLength(
-    const FittedCurve& curve, int index, int windowSize)
+auto EnergyMetrics::LocalWindowedArcLength(
+    const FittedCurve& curve, int index, int windowSize) -> double
 {
     if (curve.size() <= 0) {
         return 0;
@@ -101,8 +101,8 @@ double EnergyMetrics::LocalWindowedArcLength(
 }
 
 // Apply LocalWindowedArcLength across the entire curve
-double EnergyMetrics::WindowedArcLength(
-    const FittedCurve& curve, int windowSize)
+auto EnergyMetrics::WindowedArcLength(const FittedCurve& curve, int windowSize)
+    -> double
 {
     // Special case - empty curve
     if (curve.size() <= 0) {

--- a/segmentation/src/FittedCurve.cpp
+++ b/segmentation/src/FittedCurve.cpp
@@ -7,7 +7,7 @@
 
 using namespace volcart::segmentation;
 
-std::vector<double> GenerateTVals(std::size_t count);
+auto GenerateTVals(std::size_t count) -> std::vector<double>;
 
 FittedCurve::FittedCurve(const std::vector<Voxel>& vs, int zIndex)
     : npoints_(vs.size()), zIndex_(zIndex), ts_(GenerateTVals(npoints_))
@@ -25,7 +25,7 @@ FittedCurve::FittedCurve(const std::vector<Voxel>& vs, int zIndex)
     }
 }
 
-std::vector<Voxel> FittedCurve::resample(double resamplePerc)
+auto FittedCurve::resample(double resamplePerc) -> std::vector<Voxel>
 {
     npoints_ = std::size_t(std::round(resamplePerc * npoints_));
 
@@ -39,7 +39,7 @@ std::vector<Voxel> FittedCurve::resample(double resamplePerc)
     return points_;
 }
 
-std::vector<Voxel> FittedCurve::sample(std::size_t numPoints) const
+auto FittedCurve::sample(std::size_t numPoints) const -> std::vector<Voxel>
 {
     std::vector<Voxel> newPoints(numPoints);
     newPoints.reserve(numPoints);
@@ -53,14 +53,14 @@ std::vector<Voxel> FittedCurve::sample(std::size_t numPoints) const
     return newPoints;
 }
 
-Voxel FittedCurve::operator()(int index) const
+auto FittedCurve::operator()(int index) const -> Voxel
 {
     assert(index >= 0 && index < int(ts_.size()) && "out of bounds");
     Pixel p = spline_(ts_[index]);
     return {p(0), p(1), double(zIndex_)};
 }
 
-std::vector<double> FittedCurve::curvature(int hstep) const
+auto FittedCurve::curvature(int hstep) const -> std::vector<double>
 {
     std::vector<double> xs, ys;
     std::tie(xs, ys) = Unzip(points_);
@@ -82,7 +82,7 @@ std::vector<double> FittedCurve::curvature(int hstep) const
     return k;
 }
 
-double FittedCurve::arclength() const
+auto FittedCurve::arclength() const -> double
 {
     double length = 0;
     for (std::size_t i = 1; i < npoints_; ++i) {
@@ -91,7 +91,7 @@ double FittedCurve::arclength() const
     return length;
 }
 
-std::vector<double> GenerateTVals(std::size_t count)
+auto GenerateTVals(std::size_t count) -> std::vector<double>
 {
     std::vector<double> ts(count);
     if (count > 0) {

--- a/segmentation/src/FloodFill.cpp
+++ b/segmentation/src/FloodFill.cpp
@@ -20,7 +20,7 @@ struct VoxelPair {
     Voxel parent;
 };
 
-std::vector<cv::Vec3i> vcs::GetNeighbors(const cv::Vec3i& v)
+auto vcs::GetNeighbors(const cv::Vec3i& v) -> std::vector<cv::Vec3i>
 {
     return {{v[0] - 1, v[1] - 1, v[2]}, {v[0], v[1] - 1, v[2]},
             {v[0] + 1, v[1] - 1, v[2]}, {v[0] - 1, v[1], v[2]},
@@ -28,18 +28,18 @@ std::vector<cv::Vec3i> vcs::GetNeighbors(const cv::Vec3i& v)
             {v[0], v[1] + 1, v[2]},     {v[0] + 1, v[1] + 1, v[2]}};
 }
 
-int vcs::EuclideanDistance(const cv::Vec3i& start, const cv::Vec3i& end)
+auto vcs::EuclideanDistance(const cv::Vec3i& start, const cv::Vec3i& end) -> int
 {
     return static_cast<int>(cv::norm(end - start));
 }
 
-std::size_t vcs::MeasureThickness(
+auto vcs::MeasureThickness(
     const cv::Vec3i& seed,
     const cv::Mat& slice,
     std::uint16_t low,
     std::uint16_t high,
     bool measureVert,
-    std::size_t maxRadius)
+    std::size_t maxRadius) -> std::size_t
 {
     int xPos{seed[0]};
     int xNeg{seed[0]};
@@ -90,12 +90,12 @@ std::size_t vcs::MeasureThickness(
     return length;
 }
 
-VoxelList vcs::DoFloodFill(
+auto vcs::DoFloodFill(
     const VoxelList& pts,
     int bound,
     cv::Mat img,
     std::uint16_t low,
-    std::uint16_t high)
+    std::uint16_t high) -> VoxelList
 {
     std::queue<VoxelPair> q;
     VoxelList mask;

--- a/segmentation/src/ForceChain.cpp
+++ b/segmentation/src/ForceChain.cpp
@@ -3,7 +3,7 @@
 using namespace volcart::segmentation;
 namespace vcs = volcart::segmentation;
 
-ForceChain& ForceChain::operator+=(const ForceChain& rhs)
+auto ForceChain::operator+=(const ForceChain& rhs) -> ForceChain&
 {
     if (data_.size() != rhs.size()) {
         throw std::domain_error("Vector sizes don't match");
@@ -16,7 +16,7 @@ ForceChain& ForceChain::operator+=(const ForceChain& rhs)
     return *this;
 }
 
-ForceChain& ForceChain::operator*=(const double& rhs)
+auto ForceChain::operator*=(const double& rhs) -> ForceChain&
 {
     std::for_each(
         std::begin(data_), std::end(data_), [rhs](Force& p) { p *= rhs; });
@@ -24,17 +24,17 @@ ForceChain& ForceChain::operator*=(const double& rhs)
     return *this;
 }
 
-ForceChain vcs::operator+(ForceChain lhs, const ForceChain& rhs)
+auto vcs::operator+(ForceChain lhs, const ForceChain& rhs) -> ForceChain
 {
     return lhs += rhs;
 }
 
-ForceChain vcs::operator*(ForceChain lhs, const double& rhs)
+auto vcs::operator*(ForceChain lhs, const double& rhs) -> ForceChain
 {
     return lhs *= rhs;
 }
 
-ForceChain vcs::operator*(const double& rhs, ForceChain lhs)
+auto vcs::operator*(const double& rhs, ForceChain lhs) -> ForceChain
 {
     return lhs *= rhs;
 }

--- a/segmentation/src/IntensityMap.cpp
+++ b/segmentation/src/IntensityMap.cpp
@@ -30,7 +30,7 @@ IntensityMap::IntensityMap(
     binWidth_ = cvRound(float(displayWidth_) / mapWidth_);
 }
 
-cv::Mat IntensityMap::draw()
+auto IntensityMap::draw() -> cv::Mat
 {
     // Repaint the drawTarget_ so we don't draw over others
     drawTarget_ = BGR_BLACK;
@@ -83,7 +83,7 @@ cv::Mat IntensityMap::draw()
 }
 
 // Finds the top 'N' maxima in the row being processed
-std::deque<std::pair<int, double>> IntensityMap::sortedMaxima()
+auto IntensityMap::sortedMaxima() -> std::deque<std::pair<int, double>>
 {
     bool includesMiddle = false;
     std::deque<std::pair<int, double>> crossings;

--- a/segmentation/src/LocalResliceParticleSim.cpp
+++ b/segmentation/src/LocalResliceParticleSim.cpp
@@ -24,7 +24,7 @@ namespace fs = volcart::filesystem;
 using std::begin;
 using std::end;
 
-std::size_t LocalResliceSegmentation::progressIterations() const
+auto LocalResliceSegmentation::progressIterations() const -> std::size_t
 {
     auto minZPoint = std::min_element(
         startingChain_.begin(), startingChain_.end(),
@@ -33,7 +33,7 @@ std::size_t LocalResliceSegmentation::progressIterations() const
     return static_cast<std::size_t>((endIndex_ - startIndex) / stepSize_);
 }
 
-LocalResliceSegmentation::PointSet LocalResliceSegmentation::compute()
+auto LocalResliceSegmentation::compute() -> LocalResliceSegmentation::PointSet
 {
     // reset progress
     progressStarted();
@@ -332,8 +332,8 @@ LocalResliceSegmentation::PointSet LocalResliceSegmentation::compute()
     return create_final_pointset_(points);
 }
 
-cv::Vec3d LocalResliceSegmentation::estimate_normal_at_index_(
-    const FittedCurve& currentCurve, int index)
+auto LocalResliceSegmentation::estimate_normal_at_index_(
+    const FittedCurve& currentCurve, int index) -> cv::Vec3d
 {
     auto currentVoxel = currentCurve(index);
     auto radius = static_cast<int>(
@@ -348,9 +348,9 @@ cv::Vec3d LocalResliceSegmentation::estimate_normal_at_index_(
     return tan3d.cross(cv::Vec3d{0, 0, 1});
 }
 
-LocalResliceSegmentation::PointSet
-LocalResliceSegmentation::create_final_pointset_(
+auto LocalResliceSegmentation::create_final_pointset_(
     const std::vector<std::vector<Voxel>>& points)
+    -> LocalResliceSegmentation::PointSet
 {
     auto rows = points.size();
     auto cols = points[0].size();
@@ -369,11 +369,11 @@ LocalResliceSegmentation::create_final_pointset_(
     return result_;
 }
 
-cv::Mat LocalResliceSegmentation::draw_particle_on_slice_(
+auto LocalResliceSegmentation::draw_particle_on_slice_(
     const FittedCurve& curve,
     int sliceIndex,
     int particleIndex,
-    bool showSpline) const
+    bool showSpline) const -> cv::Mat
 {
     auto pkgSlice = vol_->getSliceDataCopy(sliceIndex);
     pkgSlice.convertTo(

--- a/segmentation/src/Particle.cpp
+++ b/segmentation/src/Particle.cpp
@@ -3,21 +3,24 @@
 using namespace volcart::segmentation;
 namespace vcs = volcart::segmentation;
 
-Particle& Particle::operator+=(const cv::Vec3d& rhs)
+auto Particle::operator+=(const cv::Vec3d& rhs) -> Particle&
 {
     pos_ += rhs;
     return *this;
 }
 
-Particle& Particle::operator*=(const double& rhs)
+auto Particle::operator*=(const double& rhs) -> Particle&
 {
     pos_ *= rhs;
     return *this;
 }
 
-Particle vcs::operator+(Particle lhs, const cv::Vec3d& rhs)
+auto vcs::operator+(Particle lhs, const cv::Vec3d& rhs) -> Particle
 {
     return lhs += rhs;
 }
 
-Particle vcs::operator*(Particle lhs, const double& rhs) { return lhs *= rhs; }
+auto vcs::operator*(Particle lhs, const double& rhs) -> Particle
+{
+    return lhs *= rhs;
+}

--- a/segmentation/src/ParticleChain.cpp
+++ b/segmentation/src/ParticleChain.cpp
@@ -5,7 +5,7 @@
 using namespace volcart::segmentation;
 namespace vcs = volcart::segmentation;
 
-ParticleChain& ParticleChain::operator+=(const ForceChain& rhs)
+auto ParticleChain::operator+=(const ForceChain& rhs) -> ParticleChain&
 {
     if (data_.size() != rhs.size()) {
         throw std::domain_error("Vector sizes don't match");
@@ -18,7 +18,7 @@ ParticleChain& ParticleChain::operator+=(const ForceChain& rhs)
     return *this;
 }
 
-ParticleChain& ParticleChain::operator*=(const double& rhs)
+auto ParticleChain::operator*=(const double& rhs) -> ParticleChain&
 {
     std::for_each(
         std::begin(data_), std::end(data_), [rhs](Particle& p) { p *= rhs; });
@@ -26,22 +26,22 @@ ParticleChain& ParticleChain::operator*=(const double& rhs)
     return *this;
 }
 
-ParticleChain vcs::operator+(ParticleChain lhs, const ForceChain& rhs)
+auto vcs::operator+(ParticleChain lhs, const ForceChain& rhs) -> ParticleChain
 {
     return lhs += rhs;
 }
 
-ParticleChain vcs::operator+(const ForceChain& rhs, ParticleChain lhs)
+auto vcs::operator+(const ForceChain& rhs, ParticleChain lhs) -> ParticleChain
 {
     return lhs += rhs;
 }
 
-ParticleChain vcs::operator*(ParticleChain lhs, const double& rhs)
+auto vcs::operator*(ParticleChain lhs, const double& rhs) -> ParticleChain
 {
     return lhs *= rhs;
 }
 
-ParticleChain vcs::operator*(const double& rhs, ParticleChain lhs)
+auto vcs::operator*(const double& rhs, ParticleChain lhs) -> ParticleChain
 {
     return lhs *= rhs;
 }

--- a/segmentation/src/StructureTensorParticleSim.cpp
+++ b/segmentation/src/StructureTensorParticleSim.cpp
@@ -7,12 +7,13 @@ using namespace vc::segmentation;
 
 static constexpr double RK_STEP_SCALE = 1.0 / 6.0;
 
-std::size_t StructureTensorParticleSim::progressIterations() const
+auto StructureTensorParticleSim::progressIterations() const -> std::size_t
 {
     return static_cast<std::size_t>(std::ceil(numSteps_ / stepSize_));
 }
 
-StructureTensorParticleSim::PointSet StructureTensorParticleSim::compute()
+auto StructureTensorParticleSim::compute()
+    -> StructureTensorParticleSim::PointSet
 {
 
     progressStarted();
@@ -90,7 +91,7 @@ StructureTensorParticleSim::PointSet StructureTensorParticleSim::compute()
     return result_;
 }
 
-bool StructureTensorParticleSim::chain_stopped_()
+auto StructureTensorParticleSim::chain_stopped_() -> bool
 {
     return std::any_of(
         std::begin(currentChain_), std::end(currentChain_), [this](auto v) {
@@ -108,7 +109,8 @@ void StructureTensorParticleSim::add_chain_to_result_()
     result_.pushRow(row);
 }
 
-ForceChain StructureTensorParticleSim::calc_prop_forces_(ParticleChain c)
+auto StructureTensorParticleSim::calc_prop_forces_(ParticleChain c)
+    -> ForceChain
 {
     ForceChain res;
     Force zDir{0, 0, 1};
@@ -124,7 +126,8 @@ ForceChain StructureTensorParticleSim::calc_prop_forces_(ParticleChain c)
     return res;
 }
 
-ForceChain StructureTensorParticleSim::calc_spring_forces_(ParticleChain c)
+auto StructureTensorParticleSim::calc_spring_forces_(ParticleChain c)
+    -> ForceChain
 {
     ForceChain res;
     for (auto it = c.begin(); it != c.end(); it++) {

--- a/segmentation/src/ThinnedFloodFillSegmentation.cpp
+++ b/segmentation/src/ThinnedFloodFillSegmentation.cpp
@@ -27,7 +27,7 @@ using Voxel = cv::Vec3i;
 using VoxelList = std::vector<cv::Vec3i>;
 using VoxelSet = std::unordered_set<Voxel, Vec3iHash>;
 
-static VoxelSet FindIntersections(const VoxelSet& pts)
+static auto FindIntersections(const VoxelSet& pts) -> VoxelSet
 {
     VoxelSet intersections;
     for (const auto& v : pts) {
@@ -50,7 +50,7 @@ static VoxelSet FindIntersections(const VoxelSet& pts)
  * Search the skeleton for spurs.
  * An 'intersection' where more than two paths are available contains a spur.
  * */
-static VoxelSet PruneSpurs(VoxelSet skeleton, std::size_t spurLength)
+static auto PruneSpurs(VoxelSet skeleton, std::size_t spurLength) -> VoxelSet
 {
     auto intersections = FindIntersections(skeleton);
 
@@ -123,7 +123,7 @@ static VoxelSet PruneSpurs(VoxelSet skeleton, std::size_t spurLength)
     return skeleton;
 }
 
-static bool ThinPts(int dir, VoxelSet& pts)
+static auto ThinPts(int dir, VoxelSet& pts) -> bool
 {
     std::vector<Voxel> ptsToRemove;
     for (const Voxel& v : pts) {
@@ -204,7 +204,7 @@ static bool ThinPts(int dir, VoxelSet& pts)
  * Edition, by E.R. Davies. This thinning algorithm produces a centered,
  * continuous skeleton. (So long as the mask it is thinning is continuous.)
  * */
-static VoxelSet ThinMask(VoxelSet& pts)
+static auto ThinMask(VoxelSet& pts) -> VoxelSet
 {
     bool nThinned{true};
     bool sThinned{true};
@@ -219,8 +219,8 @@ static VoxelSet ThinMask(VoxelSet& pts)
     return pts;
 }
 
-static TFF::PointSet AppendVoxelSetToPointSet(
-    const VoxelSet& points, TFF::PointSet result)
+static auto AppendVoxelSetToPointSet(
+    const VoxelSet& points, TFF::PointSet result) -> TFF::PointSet
 {
     for (const auto& v : points) {
         result.emplace_back(v[0], v[1], v[2]);
@@ -235,10 +235,10 @@ void TFF::setClosingKernelSize(int s) { kernel_ = s; }
 void TFF::setMeasureVertical(bool b) { measureVertically_ = b; }
 void TFF::setSpurLengthThreshold(int length) { spurLength_ = length; }
 void TFF::setMaxRadius(std::size_t radius) { maxRadius_ = radius; }
-TFF::VoxelMask TFF::getMask() const { return volMask_; }
+auto TFF::getMask() const -> TFF::VoxelMask { return volMask_; }
 void TFF::setDumpVis(bool b) { dumpVis_ = b; }
 
-TFF::PointSet TFF::compute()
+auto TFF::compute() -> TFF::PointSet
 {
     // Setup debug vis directories
     const fs::path outputDir("debugvis");

--- a/segmentation/test/CubicSplineTest.cpp
+++ b/segmentation/test/CubicSplineTest.cpp
@@ -14,7 +14,7 @@ using namespace volcart::segmentation;
 // Global float comparison percent tolerance
 static const double floatComparePercentTolerance = 0.01;  // %
 
-std::vector<double> generateTVals(std::size_t count);
+auto generateTVals(std::size_t count) -> std::vector<double>;
 
 // Fixture for a spline parameterizing y = 1
 struct ConstantCubicSpline {
@@ -32,7 +32,7 @@ struct ConstantCubicSpline {
         _spline = CubicSpline<double>(xs, ys);
     }
 
-    decltype(_spline) makeSpline()
+    auto makeSpline() -> decltype(_spline)
     {
         std::vector<double> xs(_knotCount), ys(_knotCount);
         std::iota(std::begin(xs), std::end(xs), 0.0);
@@ -55,7 +55,7 @@ struct ParabolicCubicSpline {
     {
     }
 
-    decltype(_spline) makeSpline()
+    auto makeSpline() -> decltype(_spline)
     {
         // Fill x values
         std::vector<double> xs(_knotCount), ys(_knotCount);
@@ -141,7 +141,7 @@ TEST(CubicSplineTest, YEqualsXSquaredValues)
     }
 }
 
-std::vector<double> generateTVals(std::size_t count)
+auto generateTVals(std::size_t count) -> std::vector<double>
 {
     std::vector<double> ts(count);
     ts.front() = 0;

--- a/segmentation/test/FittedCurveTest.cpp
+++ b/segmentation/test/FittedCurveTest.cpp
@@ -14,7 +14,7 @@ using namespace volcart::segmentation;
 // Global float comparison percent tolerance
 static const double tol = 0.01;  // %
 
-std::vector<double> makeTVals(std::size_t count);
+auto makeTVals(std::size_t count) -> std::vector<double>;
 
 // Fixture for a constant line y = 1
 struct ConstantFittedCurve {
@@ -189,7 +189,7 @@ TEST(CircleFittedCurve, EvenlySampledCircleCurveHasEvenlySpacedPoints)
     }
 }
 
-std::vector<double> makeTVals(std::size_t count)
+auto makeTVals(std::size_t count) -> std::vector<double>
 {
     std::vector<double> ts(count);
     ts.front() = 0;

--- a/segmentation/test/IntensityMapTest.cpp
+++ b/segmentation/test/IntensityMapTest.cpp
@@ -20,8 +20,9 @@ static const double perc = 0.01;  // %
 static const std::size_t WIDTH = 32;
 static const std::size_t HEIGHT = 32;
 
-cv::Mat_<std::uint16_t> makeLinearIntensityProfile(
-    const std::vector<std::pair<std::size_t, std::uint16_t>> maxima);
+auto makeLinearIntensityProfile(
+    const std::vector<std::pair<std::size_t, std::uint16_t>> maxima)
+    -> cv::Mat_<std::uint16_t>;
 
 // Fixture to generate a reslice
 class ResliceFixture : public ::testing::Test

--- a/segmentation/test/LocalResliceParticleSimTest.cpp
+++ b/segmentation/test/LocalResliceParticleSimTest.cpp
@@ -15,9 +15,9 @@ struct PointXYZ {
     explicit PointXYZ(const cv::Vec3d& p) : x(p[0]), y(p[1]), z(p[2]) {}
 };
 
-std::ostream& operator<<(std::ostream& s, PointXYZ p);
+auto operator<<(std::ostream& s, PointXYZ p) -> std::ostream&;
 
-inline double NormL2(const PointXYZ p1, const PointXYZ p2)
+inline auto NormL2(const PointXYZ p1, const PointXYZ p2) -> double
 {
     return std::sqrt(
         (p1.x - p2.x) * (p1.x - p2.x) + (p1.y - p2.y) * (p1.y - p2.y) +
@@ -117,7 +117,7 @@ TEST_F(LocalResliceSegmentationFix, DefaultSegmentationTest)
     EXPECT_TRUE(diffCount < maxAllowedDiffCount);
 }
 
-std::ostream& operator<<(std::ostream& s, PointXYZ p)
+auto operator<<(std::ostream& s, PointXYZ p) -> std::ostream&
 {
     return s << "[" << p.x << ", " << p.y << ", " << p.z << "]";
 }

--- a/segmentation/test/LocalResliceParticleSimTest.cpp
+++ b/segmentation/test/LocalResliceParticleSimTest.cpp
@@ -113,7 +113,7 @@ TEST_F(LocalResliceSegmentationFix, DefaultSegmentationTest)
     auto maxAllowedDiffCount =
         std::size_t(std::round(0.1 * groundTruthCloud.size()));
     std::cout << "# different points: " << diffCount
-              << " (max allowed: " << maxAllowedDiffCount << ")" << std::endl;
+              << " (max allowed: " << maxAllowedDiffCount << ")" << '\n';
     EXPECT_TRUE(diffCount < maxAllowedDiffCount);
 }
 

--- a/texturing/src/AlignmentMarkerGenerator.cpp
+++ b/texturing/src/AlignmentMarkerGenerator.cpp
@@ -19,7 +19,7 @@ using namespace volcart::texturing;
 namespace vcm = volcart::meshing;
 
 // Convert HSV values to RGB
-cv::Scalar HSVtoRGB(float h, float s, float v);
+auto HSVtoRGB(float h, float s, float v) -> cv::Scalar;
 
 AlignmentMarkerGenerator::LineSegment::LineSegment(
     const cv::Vec3d& a, const cv::Vec3d& b, cv::Scalar c)
@@ -45,12 +45,12 @@ void AlignmentMarkerGenerator::setMarkerUseRandomColor(bool b)
     markerRandomColor_ = b;
 }
 
-std::vector<cv::Mat> AlignmentMarkerGenerator::getMarkedImages() const
+auto AlignmentMarkerGenerator::getMarkedImages() const -> std::vector<cv::Mat>
 {
     return output_;
 }
 
-std::vector<cv::Mat> AlignmentMarkerGenerator::compute()
+auto AlignmentMarkerGenerator::compute() -> std::vector<cv::Mat>
 {
     // Setup output
     output_.clear();
@@ -146,7 +146,7 @@ std::vector<cv::Mat> AlignmentMarkerGenerator::compute()
     return output_;
 }
 
-cv::Scalar HSVtoRGB(float h, float s, float v)
+auto HSVtoRGB(float h, float s, float v) -> cv::Scalar
 {
     cv::Mat hsv(1, 1, CV_32FC3, cv::Scalar(h, s, v));
     cv::Mat rgb;

--- a/texturing/src/AngleBasedFlattening.cpp
+++ b/texturing/src/AngleBasedFlattening.cpp
@@ -28,7 +28,7 @@ void AngleBasedFlattening::setABFMaxIterations(std::size_t i)
 }
 
 ///// Process //////
-ITKMesh::Pointer AngleBasedFlattening::compute()
+auto AngleBasedFlattening::compute() -> ITKMesh::Pointer
 {
     // Construct HEM
     auto hem = HalfEdgeMesh::New();

--- a/texturing/src/FlatteningAlgorithm.cpp
+++ b/texturing/src/FlatteningAlgorithm.cpp
@@ -8,7 +8,7 @@ using namespace volcart::texturing;
 
 namespace mm = volcart::meshmath;
 
-UVMap::Pointer FlatteningAlgorithm::getUVMap()
+auto FlatteningAlgorithm::getUVMap() -> UVMap::Pointer
 {
     // Setup uvMap
     auto uvMap = UVMap::New();

--- a/texturing/src/FlatteningError.cpp
+++ b/texturing/src/FlatteningError.cpp
@@ -14,9 +14,9 @@ using namespace volcart;
 using namespace volcart::texturing;
 namespace vct = volcart::texturing;
 
-std::vector<cv::Vec3d> GetCellVertices(
+auto GetCellVertices(
     const ITKMesh::Pointer& mesh,
-    const ITKCell::PointIdentifierContainerType& ids)
+    const ITKCell::PointIdentifierContainerType& ids) -> std::vector<cv::Vec3d>
 {
 
     // Output vector
@@ -31,13 +31,13 @@ std::vector<cv::Vec3d> GetCellVertices(
     return pts;
 }
 
-static std::tuple<double, double, double, double, double> CalculateGammas(
+static auto CalculateGammas(
     const cv::Vec3d& p1,
     const cv::Vec3d& p2,
     const cv::Vec3d& p3,
     const cv::Vec3d& q1,
     const cv::Vec3d& q2,
-    const cv::Vec3d& q3)
+    const cv::Vec3d& q3) -> std::tuple<double, double, double, double, double>
 {
     // Calculate 2D area
     auto a = cv::norm(p2 - p1);
@@ -71,20 +71,21 @@ static std::tuple<double, double, double, double, double> CalculateGammas(
     return {max, min, a, b, c};
 }
 
-static std::pair<double, double> TriLStretch(
+static auto TriLStretch(
     const cv::Vec3d& p0,
     const cv::Vec3d& p1,
     const cv::Vec3d& p2,
     const cv::Vec3d& q0,
     const cv::Vec3d& q1,
-    const cv::Vec3d& q2)
+    const cv::Vec3d& q2) -> std::pair<double, double>
 {
     const auto& [max, min, a, b, c] = CalculateGammas(p0, p1, p2, q0, q1, q2);
     return {std::sqrt(0.5 * (a + c)), max};
 }
 
-LStretchMetrics vct::LStretch(
+auto vct::LStretch(
     const ITKMesh::Pointer& mesh3D, const ITKMesh::Pointer& mesh2D)
+    -> LStretchMetrics
 {
     if (mesh3D->GetNumberOfCells() != mesh2D->GetNumberOfCells()) {
         throw std::runtime_error(
@@ -138,7 +139,8 @@ LStretchMetrics vct::LStretch(
     return metrics;
 }
 
-LStretchMetrics vct::InvertLStretchMetrics(const LStretchMetrics& metrics)
+auto vct::InvertLStretchMetrics(const LStretchMetrics& metrics)
+    -> LStretchMetrics
 {
     LStretchMetrics out;
 
@@ -160,12 +162,12 @@ LStretchMetrics vct::InvertLStretchMetrics(const LStretchMetrics& metrics)
 }
 
 // Function for creating a plot legend bar for LStretch metrics
-static cv::Mat CreateLegend(
+static auto CreateLegend(
     int width,
     float min,
     float max,
     const cv::Mat& lut,
-    const std::string& label = "")
+    const std::string& label = "") -> cv::Mat
 {
     // Keep track of the original requested width
     // Will render at high-res and resample to orig width
@@ -247,11 +249,11 @@ static cv::Mat CreateLegend(
     return bar;
 }
 
-std::vector<cv::Mat> vct::PlotLStretchError(
+auto vct::PlotLStretchError(
     const LStretchMetrics& metrics,
     const cv::Mat& cellMap,
     ColorMap cm,
-    bool drawLegend)
+    bool drawLegend) -> std::vector<cv::Mat>
 {
     // Get easy handles to the metrics
     const auto& faceL2 = metrics.faceL2;

--- a/texturing/src/IntersectionTexture.cpp
+++ b/texturing/src/IntersectionTexture.cpp
@@ -14,7 +14,7 @@ auto IntersectionTexture::New() -> Pointer
     return std::make_shared<IntersectionTexture>();
 }
 
-Texture IntersectionTexture::compute()
+auto IntersectionTexture::compute() -> Texture
 {
     // Setup
     result_.clear();

--- a/texturing/src/OrthographicProjectionFlattening.cpp
+++ b/texturing/src/OrthographicProjectionFlattening.cpp
@@ -12,13 +12,13 @@ using namespace volcart;
 using namespace texturing;
 namespace vcm = volcart::meshing;
 
-OrthographicProjectionFlattening::Pointer
-OrthographicProjectionFlattening::New()
+auto OrthographicProjectionFlattening::New()
+    -> OrthographicProjectionFlattening::Pointer
 {
     return std::make_shared<OrthographicProjectionFlattening>();
 }
 
-ITKMesh::Pointer OrthographicProjectionFlattening::compute()
+auto OrthographicProjectionFlattening::compute() -> ITKMesh::Pointer
 {
     // Setup output
     output_ = ITKMesh::New();

--- a/texturing/src/ScaleMarkerGenerator.cpp
+++ b/texturing/src/ScaleMarkerGenerator.cpp
@@ -22,7 +22,7 @@ static constexpr int TEXT_OFFSET_X = 10;
 static constexpr int TEXT_OFFSET_Y = 5;
 static constexpr int SCALE_WIDTH = 200;
 
-cv::Mat vct::ScaleMarkerGenerator::compute()
+auto vct::ScaleMarkerGenerator::compute() -> cv::Mat
 {
     // Safety check
     if (inputImg_.empty()) {
@@ -75,7 +75,7 @@ cv::Mat vct::ScaleMarkerGenerator::compute()
     return outputImg_;
 }
 
-cv::Mat vct::ScaleMarkerGenerator::resize_ref_image_()
+auto vct::ScaleMarkerGenerator::resize_ref_image_() -> cv::Mat
 {
     // resizing the sample character
     cv::Mat resized;
@@ -92,7 +92,7 @@ cv::Mat vct::ScaleMarkerGenerator::resize_ref_image_()
     return resized;
 }
 
-cv::Mat vct::ScaleMarkerGenerator::generate_scale_bar_()
+auto vct::ScaleMarkerGenerator::generate_scale_bar_() -> cv::Mat
 {
     // Setup empty output image
     cv::Mat barImg = cv::Mat::zeros(inputImg_.rows, SCALE_WIDTH, CV_8UC3);

--- a/texturing/test/FlatteningErrorTest.cpp
+++ b/texturing/test/FlatteningErrorTest.cpp
@@ -65,7 +65,7 @@ TEST(FlatteningError, MetricsScale)
     EXPECT_THAT(metrics.faceLInf, Each(DoubleNear(expected, 1e-7)));
 }
 
-int main(int argc, char** argv)
+auto main(int argc, char** argv) -> int
 {
     ::testing::InitGoogleTest(&argc, argv);
     volcart::logging::SetLogLevel("off");

--- a/utils/src/AlignmentMarkers.cpp
+++ b/utils/src/AlignmentMarkers.cpp
@@ -19,9 +19,10 @@ namespace fs = volcart::filesystem;
 namespace vc = volcart;
 namespace vct = volcart::texturing;
 
-vct::AlignmentMarkerGenerator::LineSegment ParseLineSegString(std::string s);
+auto ParseLineSegString(std::string s)
+    -> vct::AlignmentMarkerGenerator::LineSegment;
 
-int main(int argc, char* argv[])
+auto main(int argc, char* argv[]) -> int
 {
     ///// Parse the command line options /////
     // clang-format off
@@ -155,7 +156,8 @@ int main(int argc, char* argv[])
     return EXIT_SUCCESS;
 }
 
-vct::AlignmentMarkerGenerator::LineSegment ParseLineSegString(std::string s)
+auto ParseLineSegString(std::string s)
+    -> vct::AlignmentMarkerGenerator::LineSegment
 {
     // Parse the string into doubles
     std::regex delim(",");

--- a/utils/src/ApplyColorMap.cpp
+++ b/utils/src/ApplyColorMap.cpp
@@ -18,7 +18,7 @@ namespace po = boost::program_options;
 
 namespace
 {
-float ValueMax(int cvDepth)
+auto ValueMax(int cvDepth) -> float
 {
     switch (cvDepth) {
         case CV_8U:
@@ -33,7 +33,7 @@ float ValueMax(int cvDepth)
 }
 }  // namespace
 
-int main(int argc, char* argv[])
+auto main(int argc, char* argv[]) -> int
 {
     ///// Parse the command line options /////
     // All command line options

--- a/utils/src/ApplyColorMap.cpp
+++ b/utils/src/ApplyColorMap.cpp
@@ -73,7 +73,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") > 0 || argc < 5) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 
@@ -81,7 +81,7 @@ auto main(int argc, char* argv[]) -> int
     try {
         po::notify(parsed);
     } catch (po::error& e) {
-        std::cerr << "ERROR: " << e.what() << std::endl;
+        std::cerr << "ERROR: " << e.what() << '\n';
         return EXIT_FAILURE;
     }
 

--- a/utils/src/ConvertMask.cpp
+++ b/utils/src/ConvertMask.cpp
@@ -60,7 +60,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") || argc < 2) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 

--- a/utils/src/ConvertMask.cpp
+++ b/utils/src/ConvertMask.cpp
@@ -33,9 +33,9 @@ void WriteMaskImage(
 
 using SliceList = std::map<std::size_t, fs::path>;
 void VolumeMaskToPointMask(const fs::path& inPath, const fs::path& outPath);
-SliceList CollectVolumeFiles(const fs::path& fmtPath);
+auto CollectVolumeFiles(const fs::path& fmtPath) -> SliceList;
 
-int main(int argc, char* argv[])
+auto main(int argc, char* argv[]) -> int
 {
     ///// Parse the command line options /////
     // All command line options
@@ -201,7 +201,7 @@ void VolumeMaskToPointMask(const fs::path& inPath, const fs::path& outPath)
     vc::PointSetIO<cv::Vec3i>::WritePointSet(outPath, pts);
 }
 
-SliceList CollectVolumeFiles(const fs::path& fmtPath)
+auto CollectVolumeFiles(const fs::path& fmtPath) -> SliceList
 {
     SliceList paths;
 

--- a/utils/src/ConvertPointSet.cpp
+++ b/utils/src/ConvertPointSet.cpp
@@ -28,7 +28,7 @@ void MeshToPointSet(const fs::path& inputPath, const fs::path& outputPath);
 
 po::variables_map PARSED;
 
-int main(int argc, char* argv[])
+auto main(int argc, char* argv[]) -> int
 {
     ///// Parse the command line options /////
     // All command line options

--- a/utils/src/ConvertPointSet.cpp
+++ b/utils/src/ConvertPointSet.cpp
@@ -49,7 +49,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (PARSED.count("help") || argc < 2) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 

--- a/utils/src/FlattenMesh.cpp
+++ b/utils/src/FlattenMesh.cpp
@@ -37,7 +37,7 @@ auto main(int argc, char** argv) -> int
 
     // Show the help message
     if (parsed.count("help") > 0 || argc < 2) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 
@@ -45,7 +45,7 @@ auto main(int argc, char** argv) -> int
     try {
         po::notify(parsed);
     } catch (po::error& e) {
-        std::cerr << "ERROR: " << e.what() << std::endl;
+        std::cerr << "ERROR: " << e.what() << '\n';
         return EXIT_FAILURE;
     }
 
@@ -56,7 +56,7 @@ auto main(int argc, char** argv) -> int
         useABF = false;
     } else if (method != "abf") {
         std::cerr << "ERROR: Unknown flattening method: " << method;
-        std::cerr << std::endl;
+        std::cerr << '\n';
         return EXIT_FAILURE;
     }
 

--- a/utils/src/FlattenMesh.cpp
+++ b/utils/src/FlattenMesh.cpp
@@ -13,7 +13,7 @@ namespace po = boost::program_options;
 namespace vc = volcart;
 namespace vct = volcart::texturing;
 
-int main(int argc, char** argv)
+auto main(int argc, char** argv) -> int
 {
     ///// Parse the command line options /////
     // All command line options

--- a/utils/src/FlipMesh.cpp
+++ b/utils/src/FlipMesh.cpp
@@ -16,7 +16,7 @@ namespace vc = volcart;
 // Volpkg version required by this app
 static constexpr int VOLPKG_MIN_VERSION = 6;
 
-int main(int argc, char** argv)
+auto main(int argc, char** argv) -> int
 {
     ///// Parse the command line options /////
     // All command line options

--- a/utils/src/FlipMesh.cpp
+++ b/utils/src/FlipMesh.cpp
@@ -47,7 +47,7 @@ auto main(int argc, char** argv) -> int
 
     // Show the help message
     if (parsed.count("help") > 0 || argc < 2) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 
@@ -55,7 +55,7 @@ auto main(int argc, char** argv) -> int
     try {
         po::notify(parsed);
     } catch (po::error& e) {
-        std::cerr << "ERROR: " << e.what() << std::endl;
+        std::cerr << "ERROR: " << e.what() << '\n';
         return EXIT_FAILURE;
     }
 
@@ -84,8 +84,8 @@ auto main(int argc, char** argv) -> int
         std::cerr << "Cannot load volume. ";
         std::cerr << "Please check that the Volume Package has volumes and "
                      "that the volume ID is correct."
-                  << std::endl;
-        std::cerr << e.what() << std::endl;
+                  << '\n';
+        std::cerr << e.what() << '\n';
         return EXIT_FAILURE;
     }
 

--- a/utils/src/GenerateColorMapBar.cpp
+++ b/utils/src/GenerateColorMapBar.cpp
@@ -44,7 +44,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") > 0 || argc < 3) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 
@@ -52,7 +52,7 @@ auto main(int argc, char* argv[]) -> int
     try {
         po::notify(parsed);
     } catch (po::error& e) {
-        std::cerr << "ERROR: " << e.what() << std::endl;
+        std::cerr << "ERROR: " << e.what() << '\n';
         return EXIT_FAILURE;
     }
 

--- a/utils/src/GenerateColorMapBar.cpp
+++ b/utils/src/GenerateColorMapBar.cpp
@@ -14,7 +14,7 @@ using namespace volcart;
 namespace fs = volcart::filesystem;
 namespace po = boost::program_options;
 
-int main(int argc, char* argv[])
+auto main(int argc, char* argv[]) -> int
 {
     ///// Parse the command line options /////
     // All command line options

--- a/utils/src/ImageStatistics.cpp
+++ b/utils/src/ImageStatistics.cpp
@@ -20,9 +20,9 @@ namespace fs = volcart::filesystem;
 namespace po = boost::program_options;
 namespace vc = volcart;
 
-float GetValue(int x, int y, const cv::Mat& m);
+auto GetValue(int x, int y, const cv::Mat& m) -> float;
 
-int main(int argc, char* argv[])
+auto main(int argc, char* argv[]) -> int
 {
     ///// Parse the command line options /////
     // All command line options
@@ -159,17 +159,17 @@ int main(int argc, char* argv[])
     }
     file << "class,count,mean,var,std_dev,median" << std::endl;
     for (const auto it : vc::enumerate(metrics)) {
-        file << classNames[it.first] << ",";
-        file << static_cast<std::size_t>(it.second.at("count")) << ",";
-        file << it.second.at("mean") << ",";
-        file << it.second.at("var") << ",";
-        file << it.second.at("std_dev") << ",";
+        file << classNames[it.first] << ',';
+        file << static_cast<std::size_t>(it.second.at("count")) << ',';
+        file << it.second.at("mean") << ',';
+        file << it.second.at("var") << ',';
+        file << it.second.at("std_dev") << ',';
         file << it.second.at("median") << std::endl;
     }
     file.close();
 }
 
-float GetValue(int x, int y, const cv::Mat& m)
+auto GetValue(int x, int y, const cv::Mat& m) -> float
 {
     switch (m.depth()) {
         case CV_8U:

--- a/utils/src/ImageStatistics.cpp
+++ b/utils/src/ImageStatistics.cpp
@@ -45,7 +45,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") || argc < 2) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 
@@ -157,14 +157,14 @@ auto main(int argc, char* argv[]) -> int
     if (not file.is_open()) {
         throw std::runtime_error("Couldn't open output file");
     }
-    file << "class,count,mean,var,std_dev,median" << std::endl;
+    file << "class,count,mean,var,std_dev,median" << '\n';
     for (const auto it : vc::enumerate(metrics)) {
         file << classNames[it.first] << ',';
         file << static_cast<std::size_t>(it.second.at("count")) << ',';
         file << it.second.at("mean") << ',';
         file << it.second.at("var") << ',';
         file << it.second.at("std_dev") << ',';
-        file << it.second.at("median") << std::endl;
+        file << it.second.at("median") << '\n';
     }
     file.close();
 }

--- a/utils/src/InvertCloud.cpp
+++ b/utils/src/InvertCloud.cpp
@@ -19,7 +19,7 @@ auto main(int argc, char** argv) -> int
     if (argc < 5) {
         std::cout << "Usage: vc_invert_cloud [volpkg] [volume-id] [input].vcps "
                      "[output].vcps"
-                  << std::endl;
+                  << '\n';
         std::exit(-1);
     }
 
@@ -30,11 +30,11 @@ auto main(int argc, char** argv) -> int
 
     if (vpkg.version() != 5) {
         std::cerr << "ERROR: Volume package is version " << vpkg.version()
-                  << " but this program requires a version >= 5" << std::endl;
+                  << " but this program requires a version >= 5" << '\n';
         std::exit(EXIT_FAILURE);
     }
 
-    std::cout << inputPath << std::endl;
+    std::cout << inputPath << '\n';
 
     // Load the cloud
     auto input = vc::PointSetIO<cv::Vec3d>::ReadOrderedPointSet(inputPath);

--- a/utils/src/InvertCloud.cpp
+++ b/utils/src/InvertCloud.cpp
@@ -14,7 +14,7 @@
 namespace fs = volcart::filesystem;
 namespace vc = volcart;
 
-int main(int argc, char** argv)
+auto main(int argc, char** argv) -> int
 {
     if (argc < 5) {
         std::cout << "Usage: vc_invert_cloud [volpkg] [volume-id] [input].vcps "

--- a/utils/src/MergePointSets.cpp
+++ b/utils/src/MergePointSets.cpp
@@ -50,7 +50,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") || argc < 2) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 

--- a/utils/src/MergePointSets.cpp
+++ b/utils/src/MergePointSets.cpp
@@ -25,7 +25,7 @@ using psio = vc::PointSetIO<Voxel>;
  * the vcps file is named: LAST_SLICE_NUM.vcps. Otherwise
  * pruning will fail. TODO: a regex approach would be better
  * */
-int main(int argc, char* argv[])
+auto main(int argc, char* argv[]) -> int
 {
     ///// Parse the command line options /////
     // All command line options

--- a/utils/src/RepairPointSets.cpp
+++ b/utils/src/RepairPointSets.cpp
@@ -37,7 +37,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (args.count("help") > 0 or argc < 3) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 

--- a/utils/src/RetextureMesh.cpp
+++ b/utils/src/RetextureMesh.cpp
@@ -34,7 +34,7 @@ auto main(int argc, char** argv) -> int
 
     // Show the help message
     if (parsed.count("help") || argc < 2) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 
@@ -42,7 +42,7 @@ auto main(int argc, char** argv) -> int
     try {
         po::notify(parsed);
     } catch (po::error& e) {
-        std::cerr << "ERROR: " << e.what() << std::endl;
+        std::cerr << "ERROR: " << e.what() << '\n';
         return EXIT_FAILURE;
     }
 

--- a/utils/src/RetextureMesh.cpp
+++ b/utils/src/RetextureMesh.cpp
@@ -12,7 +12,7 @@ namespace fs = volcart::filesystem;
 namespace po = boost::program_options;
 namespace vc = volcart;
 
-int main(int argc, char** argv)
+auto main(int argc, char** argv) -> int
 {
     ///// Parse the command line options /////
     // All command line options

--- a/utils/src/SegToPointMask.cpp
+++ b/utils/src/SegToPointMask.cpp
@@ -20,7 +20,7 @@ namespace vcs = volcart::segmentation;
 void WriteMaskImage(
     int idx, std::size_t pad, const fs::path& dir, const cv::Mat& img);
 
-int main(int argc, char* argv[])
+auto main(int argc, char* argv[]) -> int
 {
     ///// Parse the command line options /////
     // All command line options

--- a/utils/src/SegToPointMask.cpp
+++ b/utils/src/SegToPointMask.cpp
@@ -60,7 +60,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") || argc < 2) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 
@@ -90,8 +90,8 @@ auto main(int argc, char* argv[]) -> int
         std::cerr << "Cannot load volume. ";
         std::cerr << "Please check that the Volume Package has volumes and "
                      "that the volume ID is correct."
-                  << std::endl;
-        std::cerr << e.what() << std::endl;
+                  << '\n';
+        std::cerr << e.what() << '\n';
         return EXIT_FAILURE;
     }
 

--- a/utils/src/SurfArea.cpp
+++ b/utils/src/SurfArea.cpp
@@ -16,7 +16,7 @@
 auto main(int argc, char** argv) -> int
 {
     if (argc < 3) {
-        std::cout << "Usage: vc_area volpkg seg-id" << std::endl;
+        std::cout << "Usage: vc_area volpkg seg-id" << '\n';
         exit(-1);
     }
 

--- a/utils/src/SurfArea.cpp
+++ b/utils/src/SurfArea.cpp
@@ -13,7 +13,7 @@
 #include "vc/meshing/ITK2VTK.hpp"
 #include "vc/meshing/OrderedPointSetMesher.hpp"
 
-int main(int argc, char** argv)
+auto main(int argc, char** argv) -> int
 {
     if (argc < 3) {
         std::cout << "Usage: vc_area volpkg seg-id" << std::endl;

--- a/utils/src/TransformMesh.cpp
+++ b/utils/src/TransformMesh.cpp
@@ -56,7 +56,7 @@ auto main(int argc, char** argv) -> int
 
     // Show the help message
     if (parsed.count("help") > 0 || argc < 2) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 
@@ -64,7 +64,7 @@ auto main(int argc, char** argv) -> int
     try {
         po::notify(parsed);
     } catch (po::error& e) {
-        std::cerr << "ERROR: " << e.what() << std::endl;
+        std::cerr << "ERROR: " << e.what() << '\n';
         return EXIT_FAILURE;
     }
 

--- a/utils/src/TransformMesh.cpp
+++ b/utils/src/TransformMesh.cpp
@@ -23,7 +23,7 @@ using MeshTransformer =
 using TransformWriter = itk::TransformFileWriterTemplate<double>;
 using TransformReader = itk::TransformFileReaderTemplate<double>;
 
-int main(int argc, char** argv)
+auto main(int argc, char** argv) -> int
 {
     ///// Parse the command line options /////
     // All command line options

--- a/utils/src/TransformUV.cpp
+++ b/utils/src/TransformUV.cpp
@@ -59,7 +59,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") > 0 || argc < 2) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 

--- a/utils/src/UVMaptoFlatMesh.cpp
+++ b/utils/src/UVMaptoFlatMesh.cpp
@@ -35,7 +35,7 @@ auto main(int argc, char** argv) -> int
 
     // Show the help message
     if (parsed.count("help") > 0 || argc < 2) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 
@@ -43,7 +43,7 @@ auto main(int argc, char** argv) -> int
     try {
         po::notify(parsed);
     } catch (po::error& e) {
-        std::cerr << "ERROR: " << e.what() << std::endl;
+        std::cerr << "ERROR: " << e.what() << '\n';
         return EXIT_FAILURE;
     }
 

--- a/utils/src/UVMaptoFlatMesh.cpp
+++ b/utils/src/UVMaptoFlatMesh.cpp
@@ -12,7 +12,7 @@ namespace fs = volcart::filesystem;
 namespace po = boost::program_options;
 namespace vc = volcart;
 
-int main(int argc, char** argv)
+auto main(int argc, char** argv) -> int
 {
     ///// Parse the command line options /////
     // All command line options

--- a/utils/src/VisualizePPM.cpp
+++ b/utils/src/VisualizePPM.cpp
@@ -39,7 +39,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") > 0 || argc < 2) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 

--- a/utils/src/VolpkgUpgrade.cpp
+++ b/utils/src/VolpkgUpgrade.cpp
@@ -8,7 +8,7 @@
 namespace fs = volcart::filesystem;
 namespace vc = volcart;
 
-int main(int argc, char* argv[])
+auto main(int argc, char* argv[]) -> int
 {
     if (argc < 2) {
         std::cerr << "Usage: " << argv[0] << " [volpkg]\n";

--- a/utils/src/VolumeBump.cpp
+++ b/utils/src/VolumeBump.cpp
@@ -62,7 +62,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Show the help message
     if (parsed.count("help") || argc < 11) {
-        std::cout << all << std::endl;
+        std::cout << all << '\n';
         return EXIT_SUCCESS;
     }
 

--- a/utils/src/VolumeBump.cpp
+++ b/utils/src/VolumeBump.cpp
@@ -31,7 +31,7 @@ std::size_t g_numSliceChars;
 
 void WriteBumpedSlice(const cv::Mat& slice, int index);
 
-int main(int argc, char* argv[])
+auto main(int argc, char* argv[]) -> int
 {
     ///// Parse the command line options /////
     // clang-format off


### PR DESCRIPTION
Refactor the entire code base to use trailing return types. Also replace `std::endl` with `\n` in places where we don't need immediate buffer flushing.