### PR TITLE
Check for failures in IO classes

### DIFF
--- a/apps/src/VolumeServerApp.cpp
+++ b/apps/src/VolumeServerApp.cpp
@@ -96,7 +96,7 @@ auto main(int argc, char* argv[]) -> int
                 return EXIT_FAILURE;
             }
             volpkgs.insert({volpkg.name(), volpkg});
-        } catch (std::runtime_error& e) {
+        } catch (std::exception& e) {
             vc::Logger()->error(
                 "Failed to load volume package: {}: {}", volpkgPath, e.what());
             return EXIT_FAILURE;

--- a/core/include/vc/core/io/ImageIO.hpp
+++ b/core/include/vc/core/io/ImageIO.hpp
@@ -39,6 +39,8 @@ struct WriteImageOpts {
  *
  * Uses volcart::WriteTIFF for all tiff images, which includes support for
  * transparency and floating-point images. Otherwise, uses cv::imwrite.
+ *
+ * @throws volcart::IOException
  */
 void WriteImage(
     const filesystem::path& path, const cv::Mat& img, WriteImageOpts = {});

--- a/core/include/vc/core/io/OBJWriter.hpp
+++ b/core/include/vc/core/io/OBJWriter.hpp
@@ -75,8 +75,10 @@ public:
     /** @brief Write the OBJ to disk
      *
      * If UV Map is not empty, automatically writes MTL and texture image.
+     *
+     * @throws volcart::IOException
      */
-    auto write() -> int;
+    void write();
     /**@}*/
 
 private:
@@ -109,20 +111,20 @@ private:
     cv::Mat texture_;
 
     /** Write the OBJ file */
-    auto write_obj_() -> int;
+    void write_obj_();
     /** Write the MTL file */
-    auto write_mtl_() -> int;
+    void write_mtl_();
     /** Write the texture file */
-    auto write_texture_() -> int;
+    void write_texture_();
 
     /** Write the OBJ header */
-    auto write_header_() -> int;
+    void write_header_();
     /** Write the OBJ vertices */
-    auto write_vertices_() -> int;
+    void write_vertices_();
     /** Write the OBJ texture coordinates */
-    auto write_texture_coordinates_() -> int;
+    void write_texture_coordinates_();
     /** Write the OBJ faces */
-    auto write_faces_() -> int;
+    void write_faces_();
 };
 
 }  // namespace volcart::io

--- a/core/include/vc/core/io/PLYWriter.hpp
+++ b/core/include/vc/core/io/PLYWriter.hpp
@@ -70,8 +70,10 @@ public:
      *
      * If UV Map is not empty, automatically writes per-vertex texture
      * information.
+     *
+     * @throws volcart::IOException
      */
-    auto write() -> int;
+    void write();
     /**@}*/
 
 private:
@@ -89,7 +91,7 @@ private:
     std::vector<std::uint16_t> vcolors_;
 
     /** @brief Write the PLY header */
-    auto write_header_() -> int;
+    void write_header_();
 
     /**
      * @brief Write the PLY vertices
@@ -98,13 +100,13 @@ private:
      *
      * `x y z nx ny nz`
      */
-    auto write_vertices_() -> int;
+    void write_vertices_();
     /**@brief Write the PLY faces
      *
      * Lines are formatted:
      *
      * `[n vertices in face] v1 v2 ... vn`
      */
-    auto write_faces_() -> int;
+    void write_faces_();
 };
 }  // namespace volcart::io

--- a/core/include/vc/core/io/TIFFIO.hpp
+++ b/core/include/vc/core/io/TIFFIO.hpp
@@ -65,7 +65,7 @@ enum class Compression {
  * format.
  *
  * @param path Path to TIFF file
- * @throws std::runtime_error Unrecoverable read errors
+ * @throws volcart::IOException Unrecoverable read errors
  */
 auto ReadTIFF(const volcart::filesystem::path& path) -> cv::Mat;
 
@@ -77,7 +77,7 @@ auto ReadTIFF(const volcart::filesystem::path& path) -> cv::Mat;
  * are assumed to have a BGR channel order, except for 8-bit and 16-bit signed
  * integer types which are not supported.
  *
- * @throws std::runtime_error All writing errors
+ * @throws volcart::IOException All writing errors
  */
 void WriteTIFF(
     const volcart::filesystem::path& path,

--- a/core/include/vc/core/io/UVMapIO.hpp
+++ b/core/include/vc/core/io/UVMapIO.hpp
@@ -5,9 +5,17 @@
 
 namespace volcart::io
 {
-/** @brief Write a UVMap in the custom .uvm archival format */
+/**
+ * @brief Write a UVMap in the custom .uvm archival format
+ *
+ * @throws volcart::IOException
+ */
 void WriteUVMap(const filesystem::path& path, const UVMap& uvMap);
 
-/** @brief Read a UVMap from the custom .uvm archival format */
+/**
+ * @brief Read a UVMap from the custom .uvm archival format
+ *
+ * @throws volcart::IOException
+ */
 auto ReadUVMap(const filesystem::path& path) -> UVMap;
 }  // namespace volcart::io

--- a/core/include/vc/core/types/Metadata.hpp
+++ b/core/include/vc/core/types/Metadata.hpp
@@ -33,7 +33,11 @@ public:
     /** @brief Default constructor */
     Metadata() = default;
 
-    /** @brief Read a metadata file from disk */
+    /**
+     * @brief Read a metadata file from disk
+     *
+     * @throws volcart::IOException
+     */
     explicit Metadata(volcart::filesystem::path fileLocation);
     /**@}*/
 
@@ -44,7 +48,11 @@ public:
     /** @brief Set the path where the metadata file will be written */
     void setPath(const volcart::filesystem::path& path) { path_ = path; }
 
-    /** @brief Save the metadata file to the stored path */
+    /**
+     * @brief Save the metadata file to the stored path
+     *
+     * @throws volcart::IOException 
+     */
     void save() { save(path_); }
 
     /** @brief Save the metadata file to a specified path */

--- a/core/src/ImageIO.cpp
+++ b/core/src/ImageIO.cpp
@@ -4,6 +4,7 @@
 
 #include "vc/core/io/FileExtensionFilter.hpp"
 #include "vc/core/io/TIFFIO.hpp"
+#include "vc/core/types/Exceptions.hpp"
 #include "vc/core/util/ImageConversion.hpp"
 #include "vc/core/util/Logging.hpp"
 
@@ -82,6 +83,9 @@ void vc::WriteImage(
             params.push_back(*opts.compression);
         }
 
-        cv::imwrite(path.string(), output, params);
+        if (not cv::imwrite(path.string(), output, params)) {
+            auto msg = "failure writing file '" + path.string() + "'";
+            throw IOException(msg);
+        }
     }
 }

--- a/core/src/Metadata.cpp
+++ b/core/src/Metadata.cpp
@@ -1,5 +1,7 @@
 #include "vc/core/types/Metadata.hpp"
 
+#include "vc/core/types/Exceptions.hpp"
+
 namespace fs = volcart::filesystem;
 
 using namespace volcart;
@@ -10,18 +12,18 @@ Metadata::Metadata(fs::path fileLocation) : path_{fileLocation}
     // open the file
     if (!fs::exists(fileLocation)) {
         auto msg = "could not find json file '" + fileLocation.string() + "'";
-        throw std::runtime_error(msg);
+        throw IOException(msg);
     }
     std::ifstream jsonFile(fileLocation.string());
     if (!jsonFile) {
         auto msg = "could not open json file '" + fileLocation.string() + "'";
-        throw std::ifstream::failure(msg);
+        throw IOException(msg);
     }
 
     jsonFile >> json_;
     if (jsonFile.bad()) {
         auto msg = "could not read json file '" + fileLocation.string() + "'";
-        throw std::ifstream::failure(msg);
+        throw IOException(msg);
     }
 }
 
@@ -35,6 +37,6 @@ void Metadata::save(const fs::path& path)
     jsonFile << json_ << '\n';
     if (jsonFile.fail()) {
         auto msg = "could not write json file '" + path.string() + "'";
-        throw std::ifstream::failure(msg);
+        throw IOException(msg);
     }
 }

--- a/core/src/UVMapIO.cpp
+++ b/core/src/UVMapIO.cpp
@@ -44,7 +44,12 @@ void vio::WriteUVMap(const fs::path& path, const UVMap& uvMap)
         outfile.write(reinterpret_cast<const char*>(uv.val), nbytes);
     }
 
+    outfile.flush();
     outfile.close();
+    if (outfile.fail()) {
+        auto msg = "failure writing file '" + path.string() + "'";
+        throw IOException(msg);
+    }
 }
 
 auto vio::ReadUVMap(const fs::path& path) -> UVMap

--- a/core/test/TIFFIOTest.cpp
+++ b/core/test/TIFFIOTest.cpp
@@ -7,7 +7,9 @@
 #include <opencv2/core.hpp>
 
 #include "vc/core/io/TIFFIO.hpp"
+#include "vc/core/types/Exceptions.hpp"
 
+using namespace volcart;
 using namespace volcart::tiffio;
 namespace fs = volcart::filesystem;
 
@@ -201,7 +203,7 @@ TEST(TIFFIO, Write8SC3)
 
     const fs::path imgPath(
         "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
-    EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
+    EXPECT_THROW(WriteTIFF(imgPath, img), IOException);
 }
 
 TEST(TIFFIO, Write8SC4)
@@ -214,7 +216,7 @@ TEST(TIFFIO, Write8SC4)
 
     const fs::path imgPath(
         "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
-    EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
+    EXPECT_THROW(WriteTIFF(imgPath, img), IOException);
 }
 
 TEST(TIFFIO, WriteRead16UC1)
@@ -359,7 +361,7 @@ TEST(TIFFIO, Write16SC3)
 
     const fs::path imgPath(
         "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
-    EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
+    EXPECT_THROW(WriteTIFF(imgPath, img), IOException);
 }
 
 TEST(TIFFIO, Write16SC4)
@@ -372,7 +374,7 @@ TEST(TIFFIO, Write16SC4)
 
     const fs::path imgPath(
         "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
-    EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
+    EXPECT_THROW(WriteTIFF(imgPath, img), IOException);
 }
 
 TEST(TIFFIO, WriteRead32SC1)
@@ -429,7 +431,7 @@ TEST(TIFFIO, Write32SC3)
 
     const fs::path imgPath(
         "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
-    EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
+    EXPECT_THROW(WriteTIFF(imgPath, img), IOException);
 }
 
 TEST(TIFFIO, Write32SC4)
@@ -442,7 +444,7 @@ TEST(TIFFIO, Write32SC4)
 
     const fs::path imgPath(
         "vc_core_TIFFIO_Write_" + cv::typeToString(cvType) + ".tif");
-    EXPECT_THROW(WriteTIFF(imgPath, img), std::runtime_error);
+    EXPECT_THROW(WriteTIFF(imgPath, img), IOException);
 }
 
 TEST(TIFFIO, WriteRead32FC1)


### PR DESCRIPTION
Add some checks and unify the exception type.
Throw exceptions in `PLYWriter` and `OBJWriter` instead of returning values which were never read.
Note that this changes the behavior in case one file fails. Now the whole operation is aborted.

Closes #52 