### PR TITLE
(vc_packager) Multiple volumes import

### DIFF
--- a/apps/src/Packager.cpp
+++ b/apps/src/Packager.cpp
@@ -1,7 +1,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <iostream>
-#include <iterator>
 #include <limits>
 #include <optional>
 #include <regex>

--- a/apps/src/Packager.cpp
+++ b/apps/src/Packager.cpp
@@ -334,7 +334,7 @@ auto GetVolumeInfo(const po::variables_map& parsed) -> VolumeInfo
     return info;
 }
 
-void AddVolume(const vc::VolumePkg::Pointer& volpkg, const VolumeInfo& info)
+void AddVolume(vc::VolumePkg::Pointer& volpkg, const VolumeInfo& info)
 {
     std::cout << "Adding Volume: " << info.path << std::endl;
 


### PR DESCRIPTION
Volume options are associated with the last specified slices.
For example:
`vc_packager --volpkg v.volpkg --material-thickness 1000 --name ignored --slices slices1 --name name1 --voxel-size 1 --slices slices2 --name ignored --name name2 --voxel-size 2`
is parsed as two volumes: "slices1, name1, 1" and "slices2, name2, 2".

If there is only one slices option, all volume options are associated with it.

Closes #63 