### PR TITLE
(OBJWriter) Fix mtl path being incorrectly composed

### DIFF
--- a/core/src/OBJWriter.cpp
+++ b/core/src/OBJWriter.cpp
@@ -198,7 +198,7 @@ void OBJWriter::write_texture_coordinates_()
     uvMap_->setOrigin(UVMap::Origin::BottomLeft);
 
     // Write mtl path, relative to OBJ
-    auto mtlpath = outputPath_.stem();
+    auto mtlpath = outputPath_.filename();
     mtlpath.replace_extension("mtl");
     outputMesh_ << "# Texture information\n";
     outputMesh_ << "mtllib " << mtlpath.string() << "\n";


### PR DESCRIPTION
When the output OBJ path had a dot like `path.test.obj`, then the MTL path would be incorrectly composed as `path.mtl`.