### PR TITLE
Warning instead of error for incomplete segmentation

### DIFF
--- a/core/include/vc/core/types/Metadata.hpp
+++ b/core/include/vc/core/types/Metadata.hpp
@@ -77,6 +77,10 @@ public:
             auto msg = "could not find key '" + key + "' in metadata";
             throw std::runtime_error(msg);
         }
+        if (json_[key].is_null()) {
+            T val;
+            return val;
+        }
         return json_[key].get<T>();
     }
 

--- a/core/src/Segmentation.cpp
+++ b/core/src/Segmentation.cpp
@@ -14,6 +14,9 @@ Segmentation::Segmentation(fs::path path)
     if (metadata_.get<std::string>("type") != "seg") {
         throw std::runtime_error("File not of type: seg");
     }
+    if (metadata_.get<std::string>("vcps").empty()) {
+        throw std::runtime_error("Segmentation has no pointset");
+    }
 }
 
 // Make a new Segmentation file on disk

--- a/core/src/VolumePkg.cpp
+++ b/core/src/VolumePkg.cpp
@@ -301,8 +301,14 @@ VolumePkg::VolumePkg(const fs::path& fileLocation) : rootDir_{fileLocation}
     // Load segmentations into the segmentations_
     for (const auto& entry : fs::directory_iterator(::SegsDir(rootDir_))) {
         if (fs::is_directory(entry)) {
-            auto s = Segmentation::New(entry);
-            segmentations_.emplace(s->id(), s);
+            try {
+                auto s = Segmentation::New(entry);
+                segmentations_.emplace(s->id(), s);
+            } catch (const std::exception& e) {
+                Logger()->warn(
+                    "Did not load segmentation \"{}\": {}",
+                    entry.path().filename().string(), e.what());
+            }
         }
     }
 


### PR DESCRIPTION
If meta.json is missing, or is provided but "vcps" is null, Volume Cartographer will skip the segmentation with a warning instead of creating an error.