### PR TITLE
(render) Handle conflicting uv option defaults

### DIFF
--- a/apps/src/Render.cpp
+++ b/apps/src/Render.cpp
@@ -151,7 +151,7 @@ auto GetUVOpts() -> po::options_description
                 "  2 = Orthographic Projection")
         ("uv-reuse", "If input-mesh is specified, attempt to use its existing "
             "UV map instead of generating a new one.")
-        ("uv-align-to-axis", po::value<UVMap::AlignmentAxis>()->default_value(UVMap::AlignmentAxis::ZPos, "+Z"),
+        ("uv-align-to-axis",
             "Rotate the UV map so that the specified volume direction is aligned "
             "as well as possible to \'up\' in the texture image (-Y). "
             "Performed before uv-rotate and uv-flip. Options: None, +Z, -Z, "
@@ -725,7 +725,16 @@ auto main(int argc, char* argv[]) -> int
     }
 
     // Align to axis
-    auto uvAlignAxis = parsed["uv-align-to-axis"].as<UVMap::AlignmentAxis>();
+    // Default: +Z
+    auto uvAlignAxis{UVMap::AlignmentAxis::ZPos};
+    // --uv-reuse Default: None
+    if (parsed.count("uv-reuse") > 0) {
+        uvAlignAxis = UVMap::AlignmentAxis::None;
+    }
+    // Override both defaults
+    if (parsed.count("uv-align-to-axis") > 0) {
+        uvAlignAxis = parsed["uv-align-to-axis"].as<UVMap::AlignmentAxis>();
+    }
     if (uvAlignAxis != UVMap::AlignmentAxis::None) {
         Logger()->debug("Adding UV align to axis node");
         auto align = graph->insertNode<AlignUVMapToAxisNode>();

--- a/utils/src/FlipMesh.cpp
+++ b/utils/src/FlipMesh.cpp
@@ -1,11 +1,9 @@
 #include <iostream>
 
 #include <boost/program_options.hpp>
-#include <opencv2/core.hpp>
 
 #include "vc/core/filesystem.hpp"
-#include "vc/core/io/OBJReader.hpp"
-#include "vc/core/io/OBJWriter.hpp"
+#include "vc/core/io/MeshIO.hpp"
 #include "vc/core/types/VolumePkg.hpp"
 #include "vc/core/util/Logging.hpp"
 
@@ -97,28 +95,17 @@ auto main(int argc, char** argv) -> int
 
     // Load mesh
     fs::path inputPath = parsed["input-mesh"].as<std::string>();
-    vc::io::OBJReader reader;
-    reader.setPath(inputPath);
-    auto mesh = reader.read();
+    auto [mesh, uv, texture] = vc::ReadMesh(inputPath);
 
     // Update the mesh
     for (auto pt = mesh->GetPoints()->Begin(); pt != mesh->GetPoints()->End();
-         pt++) {
+         ++pt) {
         pt->Value()[index] = volBound - pt->Value()[index];
     }
 
     // Write the new mesh
     fs::path outputPath = parsed["output-mesh"].as<std::string>();
-    vc::io::OBJWriter writer;
-    writer.setPath(outputPath);
-    writer.setMesh(mesh);
-    try {
-        writer.setUVMap(reader.getUVMap());
-        writer.setTexture(reader.getTextureMat());
-    } catch (...) {
-        // Do nothing if there's no UV map or Texture image
-    }
-    writer.write();
+    vc::WriteMesh(outputPath, mesh, uv, texture);
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
New default behavior for certain UV opts in `vc_render`:
- Default: `uv-align-to-axis=+Z` `uv-reuse=false` (no change from previous releases)
- If `uv-reuse=true`, then `uv-align-to-axis=None`, unless `--uv-align-to-axis` explicitly provided.

Closes #90.

## Other changes
- Refactor `vc_flip_mesh` to use `MeshIO` rather than `OBJReader/Writer`.