### PR TITLE
(VolPkg) Add support for transform paths

### DIFF
--- a/apps/src/Render.cpp
+++ b/apps/src/Render.cpp
@@ -521,7 +521,7 @@ auto main(int argc, char* argv[]) -> int
         // Ask the volume package for transforms
         auto tfms = vpkg->transform(srcVolId, tgtVolId);
         useTfm = tfmIdInVpkg = not tfms.empty();
-        tfmId = (tfmIdInVpkg) ? tfms[0].first : "";
+        tfmId = tfmIdInVpkg ? tfms[0].first : "";
 
         // Report no and multiple transforms
         if (tfms.empty()) {

--- a/cmake/Buildlibcore.cmake
+++ b/cmake/Buildlibcore.cmake
@@ -1,0 +1,7 @@
+FetchContent_Declare(
+    libcore
+    GIT_REPOSITORY https://github.com/educelab/libcore.git
+    GIT_TAG split-multichar-delim
+    EXCLUDE_FROM_ALL
+)
+FetchContent_MakeAvailable(libcore)

--- a/cmake/Buildlibcore.cmake
+++ b/cmake/Buildlibcore.cmake
@@ -1,7 +1,7 @@
 FetchContent_Declare(
     libcore
     GIT_REPOSITORY https://github.com/educelab/libcore.git
-    GIT_TAG split-multichar-delim
+    GIT_TAG 3fa81bd
     EXCLUDE_FROM_ALL
 )
 FetchContent_MakeAvailable(libcore)

--- a/cmake/VCFindDependencies.cmake
+++ b/cmake/VCFindDependencies.cmake
@@ -81,6 +81,9 @@ include(Buildbvh)
 ### smgl ###
 include(Buildsmgl)
 
+### libcore ###
+include(Buildlibcore)
+
 ### Boost and indicators (for app use only)
 if(VC_BUILD_APPS OR VC_BUILD_UTILS)
     find_package(Boost 1.58 REQUIRED COMPONENTS system program_options)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(VC::core ALIAS vc_core)
 target_include_directories(vc_core
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${libcore_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(vc_core

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -177,6 +177,7 @@ set(test_srcs
     test/TIFFIOTest.cpp
     test/TransformsTest.cpp
     test/SegmentationTest.cpp
+    test/VolumePkgTest.cpp
 )
 
 # Add a test executable for each src

--- a/core/include/vc/core/types/VolumePkg.hpp
+++ b/core/include/vc/core/types/VolumePkg.hpp
@@ -48,7 +48,7 @@ public:
      * @param path The location to store the VolPkg
      * @param version Version of VolumePkg you wish to construct
      */
-    VolumePkg(const filesystem::path path&, int version);
+    VolumePkg(filesystem::path path, int version);
 
     /**
      * @brief Construct a VolumePkg from a .volpkg file stored at
@@ -271,7 +271,15 @@ public:
     /**
      * @brief Get a transform by ID
      *
-     * If the provided identifier ends with "*", returns the inverse transform.
+     * If the provided ID ends with `*`, returns the inverse transform.
+     * Transform paths can be constructed with the `->` delimiter and will be
+     * returned as a composite transform:
+     * ```{.cpp}
+     * vpkg->transform("id1->id2->id3*");
+     * ```
+     * The source and target properties of the returned CompositeTransform is
+     * set to the source of the first transform and the target of the final
+     * transform (post-inversion), but the intermediate path is not verified.
      */
     [[nodiscard]] auto transform(Transform3D::Identifier id) const
         -> Transform3D::Pointer;

--- a/core/include/vc/core/types/VolumePkg.hpp
+++ b/core/include/vc/core/types/VolumePkg.hpp
@@ -255,9 +255,13 @@ public:
      * VolumePkg
      *
      * If the provided identifier ends with "*", additionally checks if the
-     * transform can be inverted.
+     * transform can be inverted. Supports transform paths using the `->`
+     * operator.
+     *
+     * @see VolumePkg::transform(Transform3D::Identifier)
      */
-    [[nodiscard]] auto hasTransform(Transform3D::Identifier id) const -> bool;
+    [[nodiscard]] auto hasTransform(const Transform3D::Identifier& id) const
+        -> bool;
 
     /** @brief Add a transform to the VolPkg */
     auto addTransform(const Transform3D::Pointer& transform)
@@ -272,7 +276,7 @@ public:
      * @brief Get a transform by ID
      *
      * If the provided ID ends with `*`, returns the inverse transform.
-     * Transform paths can be constructed with the `->` delimiter and will be
+     * Transform paths can be constructed with the `->` operator and will be
      * returned as a composite transform:
      * ```{.cpp}
      * vpkg->transform("id1->id2->id3*");

--- a/core/include/vc/core/types/VolumePkg.hpp
+++ b/core/include/vc/core/types/VolumePkg.hpp
@@ -65,14 +65,14 @@ public:
      *
      * Returns a shared pointer to the VolumePkg.
      */
-    static auto New(filesystem::path fileLocation, int version) -> Pointer;
+    static auto New(const filesystem::path& fileLocation, int version) -> Pointer;
 
     /**
      * @copybrief VolumePkg(filesystem::path fileLocation)
      *
      * Returns a shared pointer to the VolumePkg.
      */
-    static auto New(filesystem::path fileLocation) -> Pointer;
+    static auto New(const filesystem::path& fileLocation) -> Pointer;
     /**@}*/
 
     /** @name Metadata */
@@ -132,13 +132,13 @@ public:
     /**
      * @brief Saves the metadata to the VolumePkg (.volpkg) file.
      */
-    void saveMetadata();
+    void saveMetadata() const;
 
     /**
      * @brief Saves the metadata to a user-specified location.
      * @param filePath Path to output file
      */
-    void saveMetadata(const filesystem::path& filePath);
+    void saveMetadata(const filesystem::path& filePath) const;
     /**@}*/
 
     /** @name Volume Data */
@@ -282,7 +282,7 @@ public:
      * The list also includes inverse transforms which satisfy the mapping.
      */
     auto transform(const Volume::Identifier& src, const Volume::Identifier& tgt)
-        -> std::vector<
+        const -> std::vector<
             std::pair<Transform3D::Identifier, Transform3D::Pointer>>;
 
     /** @brief Get the list of transform IDs */

--- a/core/include/vc/core/types/VolumePkg.hpp
+++ b/core/include/vc/core/types/VolumePkg.hpp
@@ -289,9 +289,9 @@ public:
      * map from a source volume to a target volume
      *
      * Runs breadth-first search (BFS) to find the shortest transform paths
-     * from the source to target volume. Single-transform paths will be returned
+     * from the source to target volume. Single-transform paths are returned
      * as their original transform type (e.g. AffineTransform,
-     * IdentityTransform). Multi-transform paths will be returned as a new,
+     * IdentityTransform). Multi-transform paths are returned as a new,
      * unsimplified CompositeTransform. Paths are returned in order of
      * increasing length and may include inverse transforms which satisfy the
      * mapping.

--- a/core/include/vc/core/types/VolumePkg.hpp
+++ b/core/include/vc/core/types/VolumePkg.hpp
@@ -256,8 +256,7 @@ public:
      * If the provided identifier ends with "*", additionally checks if the
      * transform can be inverted.
      */
-
-    [[nodiscard]] auto hasTransform(Volume::Identifier id) const -> bool;
+    [[nodiscard]] auto hasTransform(Transform3D::Identifier id) const -> bool;
 
     /** @brief Add a transform to the VolPkg */
     auto addTransform(const Transform3D::Pointer& transform)
@@ -273,7 +272,8 @@ public:
      *
      * If the provided identifier ends with "*", returns the inverse transform.
      */
-    auto transform(Transform3D::Identifier id) -> Transform3D::Pointer;
+    [[nodiscard]] auto transform(Transform3D::Identifier id) const
+        -> Transform3D::Pointer;
 
     /**
      * @brief Get a list of transforms which map from a source volume to a

--- a/core/src/VolumePkg.cpp
+++ b/core/src/VolumePkg.cpp
@@ -690,7 +690,7 @@ auto VolumePkg::hasTransforms() const -> bool
     return not transforms_.empty();
 }
 
-auto VolumePkg::hasTransform(Volume::Identifier id) const -> bool
+auto VolumePkg::hasTransform(Transform3D::Identifier id) const -> bool
 {
     // Don't allow empty IDs
     if (id.empty()) {
@@ -773,7 +773,8 @@ void VolumePkg::setTransform(
     Transform3D::Save(tfmPath, transform);
 }
 
-auto VolumePkg::transform(Transform3D::Identifier id) -> Transform3D::Pointer
+auto VolumePkg::transform(Transform3D::Identifier id) const
+    -> Transform3D::Pointer
 {
     // Don't allow empty IDs
     if (id.empty()) {
@@ -781,7 +782,7 @@ auto VolumePkg::transform(Transform3D::Identifier id) -> Transform3D::Pointer
     }
 
     // Remove the star for inverse transforms
-    auto getInverse = id.back() == '*';
+    const auto getInverse = id.back() == '*';
     if (getInverse) {
         id.pop_back();
     }

--- a/core/test/VolumePkgTest.cpp
+++ b/core/test/VolumePkgTest.cpp
@@ -71,6 +71,12 @@ TEST(VolumePkg, TransformByComplexPath)
     tfm1->target("d");
     auto id1 = vpkg->addTransform(tfm1);
 
+    // Simple transform (inverse)
+    Transform3D::Pointer tfmI = IdentityTransform::New();
+    tfmI->source("d");
+    tfmI->target("a");
+    auto idI = vpkg->addTransform(tfmI) + "*";
+
     // Long path: (a->b) (b->c) (c->d)
     Transform3D::Pointer tfm2 = IdentityTransform::New();
     tfm2->source("a");
@@ -111,8 +117,9 @@ TEST(VolumePkg, TransformByComplexPath)
 
     // Note: Tests are non-overlapping paths
     auto tfms = vpkg->transform("a", "d");
-    EXPECT_EQ(tfms.size(), 3);
+    EXPECT_EQ(tfms.size(), 4);
     EXPECT_EQ(tfms[0].first, id1);
-    EXPECT_EQ(tfms[1].first, id2 + "->" + id3 + "->" + id4);
-    EXPECT_EQ(tfms[2].first, id6 + "->" + id7 + "->" + id8);
+    EXPECT_EQ(tfms[1].first, idI);
+    EXPECT_EQ(tfms[2].first, id2 + "->" + id3 + "->" + id4);
+    EXPECT_EQ(tfms[3].first, id6 + "->" + id7 + "->" + id8);
 }

--- a/core/test/VolumePkgTest.cpp
+++ b/core/test/VolumePkgTest.cpp
@@ -3,7 +3,6 @@
 #include "vc/core/types/Transforms.hpp"
 #include "vc/core/types/VolumePkg.hpp"
 #include "vc/core/types/VolumePkgVersion.hpp"
-#include "vc/core/util/Logging.hpp"
 
 using namespace volcart;
 namespace fs = filesystem;
@@ -24,6 +23,7 @@ TEST(VolumePkg, TransformByID)
     auto id = vpkg->addTransform(tfm);
 
     // Get result
+    EXPECT_TRUE(vpkg->hasTransform(id));
     auto res = vpkg->transform(id);
 
     // Pointer comparison (addTransform does not clone)
@@ -54,6 +54,7 @@ TEST(VolumePkg, TransformByIDPath)
     auto id3 = vpkg->addTransform(tfm3);
 
     // Get result
+    EXPECT_TRUE(vpkg->hasTransform(id1 + id2 + id3));
     auto res = vpkg->transform(id1 + id2 + id3);
 
     // Return type should be composite

--- a/core/test/VolumePkgTest.cpp
+++ b/core/test/VolumePkgTest.cpp
@@ -1,0 +1,99 @@
+#include <gtest/gtest.h>
+
+#include "vc/core/types/VolumePkg.hpp"
+#include "vc/core/types/VolumePkgVersion.hpp"
+#include "vc/core/types/Transforms.hpp"
+
+using namespace volcart;
+namespace fs = filesystem;
+
+TEST(VolumePkg, TransformByID)
+{
+    // Initialize new volpkg
+    fs::path p("TransformByID.volpkg");
+    fs::remove_all(p);
+    auto vpkg = VolumePkg::New(p, VOLPKG_VERSION_LATEST);
+
+    // Create transform
+    auto tfm = AffineTransform::New();
+    tfm->source("0");
+    tfm->target("1");
+
+    // Add to volpkg and get ID
+    auto id = vpkg->addTransform(tfm);
+
+    // Get result
+    auto res = vpkg->transform(id);
+
+    // Pointer comparison (addTransform does not clone)
+    EXPECT_EQ(tfm, res);
+}
+
+TEST(VolumePkg, TransformBySimplePath)
+{
+    // Initialize new volpkg
+    fs::path p("TransformBySimplePath.volpkg");
+    fs::remove_all(p);
+    auto vpkg = VolumePkg::New(p, VOLPKG_VERSION_LATEST);
+
+    Transform3D::Pointer tfm1 = AffineTransform::New();
+    tfm1->source("a");
+    tfm1->target("b");
+    auto id1 = vpkg->addTransform(tfm1);
+
+    Transform3D::Pointer tfm2 = IdentityTransform::New();
+    tfm2->source("b");
+    tfm2->target("a");
+    auto id2 = vpkg->addTransform(tfm2);
+
+    Transform3D::Pointer tfm3 = CompositeTransform::New();
+    tfm3->source("b");
+    tfm3->target("c");
+    vpkg->addTransform(tfm3);
+
+    auto tfms = vpkg->transform("a", "b");
+    EXPECT_EQ(tfms.size(), 2);
+    EXPECT_EQ(tfms[0].first, id1);
+    EXPECT_EQ(tfms[1].first, id2 + "*");
+}
+
+TEST(VolumePkg, TransformByComplexPath)
+{
+    // Initialize new volpkg
+    fs::path p("TransformByComplexPath.volpkg");
+    fs::remove_all(p);
+    auto vpkg = VolumePkg::New(p, VOLPKG_VERSION_LATEST);
+
+    Transform3D::Pointer tfm1 = IdentityTransform::New();
+    tfm1->source("a");
+    tfm1->target("d");
+    auto id1 = vpkg->addTransform(tfm1);
+
+    Transform3D::Pointer tfm2 = IdentityTransform::New();
+    tfm2->source("a");
+    tfm2->target("b");
+    auto id2 = vpkg->addTransform(tfm2);
+
+    Transform3D::Pointer tfm3 = IdentityTransform::New();
+    tfm3->source("b");
+    tfm3->target("c");
+    auto id3 = vpkg->addTransform(tfm3);
+
+    Transform3D::Pointer tfm4 = IdentityTransform::New();
+    tfm4->source("d");
+    tfm4->target("c");
+    auto id4 = vpkg->addTransform(tfm4);
+
+    Transform3D::Pointer tfm5 = IdentityTransform::New();
+    tfm5->source("e");
+    tfm5->target("d");
+    vpkg->addTransform(tfm5);
+
+    auto tfms = vpkg->transform("a", "d");
+    for(const auto& [id, tfm] : tfms) {
+        std::cout << id << ": " << tfm->source() << "->" << tfm->target() << "\n";
+    }
+    EXPECT_EQ(tfms.size(), 2);
+    EXPECT_EQ(tfms[0].first, id1);
+    EXPECT_EQ(tfms[1].first, id2 + "->" + id3 + "->" + id4 + "*");
+}


### PR DESCRIPTION
This builds off of the transform functionality added in #67 and #69 to make working with transforms a little more automatic. 

First, the single argument `VolumePkg::transform(id)` and `VolumePkg::hasTransform(id)` functions now support constructing a composite transform using the `->` operator in the id string. The inverse `*` operator is still fully supported. The following will return a composite transform containing the three identified transforms with inversion already applied to the final transform:
```c++
auto tfm = vpkg.transform("20240808111644->20240808111647->20240808111648*");
```

Second, the two argument `VolumePkg::transform(src, tgt)` function now additionally searches for multi-transform paths between the source and target volumes. Single-transform paths (what the previous implementation returned) are returned as their original transform type. Multi-transform paths are returned as a new, unsimplified `CompositeTransform`. Paths are returned in order of increasing length and may incorporate inverse transforms which help satisfy the mapping. The returned identifiers follow the form used by the new `VolumePkg::transform(id)` implementation:

```c++
auto paths = vpkg.transform("a", "d");
std::cout << "paths:\n";
for(auto [id, tfm] : paths) {
    std::cout << " - " << id << "\n";
}
/*
paths:
 - 20240808111644                                  // single-transform
 - 20240808111645*                                 // single-transform (inverted)
 - 20240808111646->20240808111647->20240808111648  // multi-transform path
*/
```

## Other changes
- VolumePkg: Add transform tests
- CompositeTransform: Add `push_front` member
- CompositeTransform: Fix bug when pushing a CompositeTransform
- core: Add libcore to include interface
- core: General clang-tidy fixes