### PR TITLE
Dockerfile: Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM ghcr.io/educelab/ci-docker:dynamic.12.0
+FROM ghcr.io/educelab/ci-docker:dynamic.12.1
 MAINTAINER Seth Parker <c.seth.parker@uky.edu>
 
 # Install volcart
 COPY ./ /volume-cartographer/
-RUN export CMAKE_PREFIX_PATH="/usr/local/Qt-6.6.1/" \
+RUN export CMAKE_PREFIX_PATH="/usr/local/Qt-6.7.2/" \
     && cmake  \
       -S /volume-cartographer/ \
       -B /volume-cartographer/build/ \
       -GNinja  \
       -DCMAKE_BUILD_TYPE=Release  \
-      -DCMAKE_INSTALL_RPATH=/usr/local/Qt-6.6.1/lib \
+      -DCMAKE_INSTALL_RPATH=/usr/local/Qt-6.7.2/lib \
       -DVC_BUILD_ACVD=ON  \
     && cmake --build /volume-cartographer/build/ \
     && cmake --install /volume-cartographer/build/ \


### PR DESCRIPTION
Updates the base for the Docker images from `ci-docker:dynamic.12.0 -> ci-docker:dynamic.12.1`. Also builds against Qt 6.7.2.