### PR TITLE
Volume: Fix bug in trilinear interpolation

### DIFF
--- a/core/src/Volume.cpp
+++ b/core/src/Volume.cpp
@@ -213,10 +213,10 @@ auto Volume::interpolateAt(const double x, const double y, const double z) const
 
     const auto c00 =
         intensityAt(x0, y0, z0) * (1 - dx) + intensityAt(x1, y0, z0) * dx;
-    const auto c10 =
-        intensityAt(x0, y1, z0) * (1 - dx) + intensityAt(x1, y0, z0) * dx;
     const auto c01 =
         intensityAt(x0, y0, z1) * (1 - dx) + intensityAt(x1, y0, z1) * dx;
+    const auto c10 =
+        intensityAt(x0, y1, z0) * (1 - dx) + intensityAt(x1, y1, z0) * dx;
     const auto c11 =
         intensityAt(x0, y1, z1) * (1 - dx) + intensityAt(x1, y1, z1) * dx;
 


### PR DESCRIPTION
Fixes typo in `Volume::interpolateAt()` which produced small errors in interpolated intensities. Fixes #104.