### PR TITLE
TIFFIO: Fix memmap endianness issues

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -96,6 +96,10 @@ jobs:
         run: |
           sudo xcode-select -s /Library/Developer/CommandLineTools
 
+      - name: Remove problematic SDKs
+        run: |
+          sudo rm -rf /Library/Developer/CommandLineTools/SDKs/MacOSX15*.sdk
+
       - name: Install dependencies
         run: |
           brew bundle

--- a/core/include/vc/core/util/MemMap.hpp
+++ b/core/include/vc/core/util/MemMap.hpp
@@ -9,6 +9,15 @@
 namespace volcart
 {
 
+namespace endian
+{
+/** Returns whether the system is little endian */
+auto little() -> bool;
+
+/** Returns whether the system is big endian */
+auto big() -> bool;
+}  // namespace endian
+
 /** @brief Memmap record */
 struct mmap_info {
     /** Whether this is a valid mapping */

--- a/core/src/MemMap.cpp
+++ b/core/src/MemMap.cpp
@@ -5,6 +5,14 @@
 namespace vc = volcart;
 namespace fs = vc::filesystem;
 
+auto vc::endian::little() -> bool
+{
+    constexpr int i{1};
+    return *reinterpret_cast<const char*>(&i) == 1;
+}
+
+auto vc::endian::big() -> bool { return not little(); }
+
 vc::mmap_info::operator bool() const { return addr and size > 0; }
 
 vc::auto_mmap_info::auto_mmap_info(const mmap_info& rhs) : mmap_info(rhs) {}


### PR DESCRIPTION
When attempting to MemMap a TIFF file, also check that the file's endianness matches that of the system.

Fixes #108.