### PR TITLE
CannySegment: Silence VTK logging

### DIFF
--- a/apps/Canny/CannySegment.cpp
+++ b/apps/Canny/CannySegment.cpp
@@ -13,10 +13,10 @@
 #include <vtkCleanPolyData.h>
 #include <vtkCutter.h>
 #include <vtkLine.h>
+#include <vtkLogger.h>
 #include <vtkPointData.h>
 #include <vtkProbeFilter.h>
 #include <vtkSmartPointer.h>
-#include <vtkLogger.h>
 
 #include "vc/app_support/ProgressIndicator.hpp"
 #include "vc/core/filesystem.hpp"

--- a/apps/Canny/CannySegment.cpp
+++ b/apps/Canny/CannySegment.cpp
@@ -16,6 +16,7 @@
 #include <vtkPointData.h>
 #include <vtkProbeFilter.h>
 #include <vtkSmartPointer.h>
+#include <vtkLogger.h>
 
 #include "vc/app_support/ProgressIndicator.hpp"
 #include "vc/core/filesystem.hpp"
@@ -89,6 +90,9 @@ auto main(int argc, char* argv[]) -> int
         std::cerr << "ERROR: " << e.what() << '\n';
         return EXIT_FAILURE;
     }
+
+    // only print VTK warnings or errors
+    vtkLogger::SetStderrVerbosity(vtkLogger::VERBOSITY_WARNING);
 
     // Canny values
     CannySettings cannySettings;


### PR DESCRIPTION
Silence the VTK INFO messages that plague `CannySegment` when computing the point cloud. Example:

```
2025-02-26 10:30:04.062 (  95.328s) [          903A4F]vtkPolyDataPlaneCutter.:589   INFO| Executing vtkPolyData plane cutter
2025-02-26 10:30:04.073 (  95.339s) [          903A4F]vtkPolyDataPlaneCutter.:589   INFO| Executing vtkPolyData plane cutter
2025-02-26 10:30:04.083 (  95.349s) [          903A4F]vtkPolyDataPlaneCutter.:589   INFO| Executing vtkPolyData plane cutter
2025-02-26 10:30:04.093 (  95.359s) [          903A4F]vtkPolyDataPlaneCutter.:589   INFO| Executing vtkPolyData plane cutter
2025-02-26 10:30:04.104 (  95.370s) [          903A4F]vtkPolyDataPlaneCutter.:589   INFO| Executing vtkPolyData plane cutter
```