### PR TITLE
ABF: Add support for other solvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ tools should be immediately available in Terminal:
 vc_render --help
 ```
 
+__NOTE:__ The macOS package is not currently built with OpenMP support.
+
 ### Using Docker
 We provide multi-architecture Docker images in the GitHub Container Registry.
 Simply pull our container and Docker will select the appropriate image for your
@@ -92,6 +94,8 @@ explicitly support other platforms.
 * Qt 6.5+: Required if building GUI applications or utilities.
 
 **Optional**
+* OpenMP: For multi-threading certain algorithms. At the moment, only 
+`AngleBasedFlattening` with the `ConjugateGradient` solver is supported.
 * Boost Filesystem 1.58+
     - This project will automatically check if the compiler provides
     `std::filesystem`. If it is not found, then Boost Filesystem is required.
@@ -176,6 +180,29 @@ cmake -S . -B build/ -DCMAKE_PREFIX_PATH=/usr/local/opt/qt/lib/cmake/
 
 # Ubuntu, Qt6 installed from source
 cmake -S . -B build/ -DCMAKE_PREFIX_PATH=/usr/local/Qt-6.5.0/lib/cmake/
+```
+
+##### Enabling OpenMP
+OpenMP support is automatically enabled when detected on the system. Often 
+OpenMP is provided by your compiler, and you don't need to do anything specific
+for CMake to find it. If your compiler provides OpenMP, please see the
+compiler's documentation for how to enable OpenMP. Support in this project can 
+be explicitly disabled by providing CMake with the `-DVC_USE_OPENMP=OFF` flag.
+
+On macOS, the compiler does not provide OpenMP, and there are many suggestions 
+for how to enable it by installing alternative compilers. If you are simply 
+building for local development, we recommend the following method which uses 
+the OpenMP libraries provided by Homebrew:
+```shell
+# install the library version of OpenMP
+brew install libomp
+
+# configure the environment so CMake can find the library
+export LDFLAGS=-L$(brew --prefix)/opt/libomp/lib
+export OpenMP_ROOT=$(brew --prefix)/opt/libomp
+
+# configure the project
+cmake -S . -B build/ # ... other configuration flags
 ```
 
 #### Unit tests

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -92,6 +92,7 @@ target_link_libraries(vc_render
     VC::graph
     ${VC_FS_LIB}
     Boost::program_options
+    Eigen3::Eigen
 )
 
 ## Render from PPM

--- a/apps/include/vc/apps/render/RenderTexturing.hpp
+++ b/apps/include/vc/apps/render/RenderTexturing.hpp
@@ -2,9 +2,6 @@
 
 #include <boost/program_options.hpp>
 
-/** Get the flattening/UV options */
-auto GetUVOpts() -> boost::program_options::options_description;
-
 /** Get the generic texture filtering options */
 auto GetFilteringOpts() -> boost::program_options::options_description;
 

--- a/apps/src/Render.cpp
+++ b/apps/src/Render.cpp
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <unordered_map>
 
+#include <Eigen/Eigen>
 #include <boost/program_options.hpp>
 #include <smgl/smgl.hpp>
 
@@ -53,6 +54,8 @@ auto GetGeneralOpts() -> po::options_description
         ("cache-memory-limit", po::value<std::string>(),
          "Maximum size of the slice cache in bytes. Accepts the suffixes: "
          "(K|M|G|T)(B). Default: 50% of the total system memory.")
+        ("threads", po::value<int>()->default_value(0),
+            "Maximum number of threads.")
         ("log-level", po::value<std::string>()->default_value("info"),
          "Options: off, critical, error, warn, info, debug");
     // clang-format on
@@ -152,6 +155,10 @@ auto GetUVOpts() -> po::options_description
                 "  0 = ABF\n"
                 "  1 = LSCM\n"
                 "  2 = Orthographic Projection")
+        ("uv-solver", po::value<int>()->default_value(0),
+            "Numerical solver method for ABF/LSCM flattening:\n"
+            "  0 = SparseLU\n"
+            "  1 = Conjugate Gradient")
         ("uv-reuse", "If input-mesh is specified, attempt to use its existing "
             "UV map instead of generating a new one.")
         ("uv-align-to-axis", po::value<UVMap::AlignmentAxis>(),
@@ -326,6 +333,9 @@ auto main(int argc, char* argv[]) -> int
 
     // Register VC graph nodes
     vc::RegisterNodes();
+
+    // Limit threads (Eigen+OpenMP)
+    Eigen::setNbThreads(parsed["threads"].as<int>());
 
     ///// Load the volume package /////
     fs::path volpkgPath = parsed["volpkg"].as<std::string>();
@@ -696,7 +706,8 @@ auto main(int argc, char* argv[]) -> int
         Logger()->debug("Adding UV computation node");
         auto method =
             static_cast<FlatteningAlgorithm>(parsed["uv-algorithm"].as<int>());
-        auto solver = static_cast<FlatteningSolver>(parsed["solver"].as<int>());
+        auto solver =
+            static_cast<FlatteningSolver>(parsed["uv-solver"].as<int>());
         if (method == FlatteningAlgorithm::ABF ||
             method == FlatteningAlgorithm::LSCM) {
             auto flatten = graph->insertNode<ABFNode>();

--- a/apps/src/Render.cpp
+++ b/apps/src/Render.cpp
@@ -32,6 +32,9 @@ enum class SmoothOpt { Off = 0, Before, After, Both };
 // Flattening algorithm opt
 enum class FlatteningAlgorithm { ABF = 0, LSCM, Orthographic };
 
+// Flattening solver opt
+using FlatteningSolver = texturing::AngleBasedFlattening::Solver;
+
 // Available texturing algorithms
 enum class Method { Composite = 0, Intersection, Integral, Thickness, Layers };
 
@@ -693,11 +696,13 @@ auto main(int argc, char* argv[]) -> int
         Logger()->debug("Adding UV computation node");
         auto method =
             static_cast<FlatteningAlgorithm>(parsed["uv-algorithm"].as<int>());
+        auto solver = static_cast<FlatteningSolver>(parsed["solver"].as<int>());
         if (method == FlatteningAlgorithm::ABF ||
             method == FlatteningAlgorithm::LSCM) {
             auto flatten = graph->insertNode<ABFNode>();
             flatten->input = *results["mesh"];
-            flatten->useABF = (method == FlatteningAlgorithm::ABF);
+            flatten->useABF = method == FlatteningAlgorithm::ABF;
+            flatten->solver = solver;
             results["uvMap"] = &flatten->uvMap;
             results["uvMesh"] = &flatten->output;
 

--- a/apps/src/RenderTexturing.cpp
+++ b/apps/src/RenderTexturing.cpp
@@ -18,6 +18,10 @@ auto GetUVOpts() -> po::options_description
                 "  2 = Orthographic Projection")
         ("reuse-uv", "If input-mesh is specified, attempt to use its existing "
             "UV map instead of generating a new one.")
+        ("uv-solver", po::value<int>()->default_value(0),
+            "Numerical solver method for ABF/LSCM flattening:\n"
+            "  0 = SparseLU\n"
+            "  1 = Conjugate Gradient")
         ("uv-rotate", po::value<double>(), "Rotate the generated UV map by an "
             "angle in degrees (counterclockwise).")
         ("uv-flip", po::value<int>(),

--- a/apps/src/RenderTexturing.cpp
+++ b/apps/src/RenderTexturing.cpp
@@ -6,45 +6,6 @@
 
 namespace po = boost::program_options;
 
-auto GetUVOpts() -> po::options_description
-{
-    // clang-format off
-    po::options_description opts("Flattening & UV Options");
-    opts.add_options()
-        ("uv-algorithm", po::value<int>()->default_value(0),
-            "Select the flattening algorithm:\n"
-                "  0 = ABF\n"
-                "  1 = LSCM\n"
-                "  2 = Orthographic Projection")
-        ("reuse-uv", "If input-mesh is specified, attempt to use its existing "
-            "UV map instead of generating a new one.")
-        ("uv-solver", po::value<int>()->default_value(0),
-            "Numerical solver method for ABF/LSCM flattening:\n"
-            "  0 = SparseLU\n"
-            "  1 = Conjugate Gradient")
-        ("uv-rotate", po::value<double>(), "Rotate the generated UV map by an "
-            "angle in degrees (counterclockwise).")
-        ("uv-flip", po::value<int>(),
-            "Flip the UV map along an axis. If uv-rotate is specified, flip is "
-            "performed after rotation.\n"
-            "Axis along which to flip:\n"
-                "  0 = Vertical\n"
-                "  1 = Horizontal\n"
-                "  2 = Both")
-        ("uv-plot", po::value<std::string>(), "Plot the UV points and save "
-            "it to the provided image path.")
-        ("uv-plot-error", po::value<std::string>(), "Plot the UV L-stretch "
-            "error metrics and save them to the provided image path. The "
-            "provided filename will have \'_l2\' and \'lInf\' appended for "
-            "each metric: e.g. providing \'foo.png\' to this argument will "
-            "produce image files \'foo_l2.png\' and \'foo_lInf.png\'")
-        ("uv-plot-error-legend", po::value<bool>()->default_value(true),
-            "If enabled (default), add a legend to the UV error plot images");
-    // clang-format on
-
-    return opts;
-}
-
 auto GetFilteringOpts() -> po::options_description
 {
     // clang-format off

--- a/cmake/VCConfig.cmake.in
+++ b/cmake/VCConfig.cmake.in
@@ -44,6 +44,11 @@ find_dependency(spdlog CONFIG QUIET REQUIRED)
 
 ### smgl ###
 find_dependency(smgl @smgl_VERSION@ CONFIG QUIET REQUIRED)
+
+### OpenMP ###
+if(@VC_USE_OPENMP@)
+    find_dependency(OpenMP QUIET REQUIRED)
+endif()
 #####################################################################
 
 ### Include VC targets ###

--- a/cmake/VCFindDependencies.cmake
+++ b/cmake/VCFindDependencies.cmake
@@ -85,6 +85,10 @@ include(Buildsmgl)
 ### libcore ###
 include(Buildlibcore)
 
+### OpenMP ###
+find_package(OpenMP)
+cmake_dependent_option(VC_USE_OPENMP "Compile with OpenMP support" ON OpenMP_CXX_FOUND OFF)
+
 ### Boost and indicators (for app use only)
 if(VC_BUILD_APPS OR VC_BUILD_UTILS)
     find_package(Boost 1.70 CONFIG REQUIRED COMPONENTS program_options)

--- a/core/include/vc/core/shapes/Arch.hpp
+++ b/core/include/vc/core/shapes/Arch.hpp
@@ -19,7 +19,7 @@ namespace volcart::shapes
  * This class generates a half-circle arch shape, like a half-pipe. The width
  * parameter determines the number of points on the circumference of one arch of
  * the half-pipe. The height determines the number of arches, which can be
- * thought of as the the length of the half-pipe. Each arch is separated by
+ * thought of as the length of the half-pipe. Each arch is separated by
  * 1 unit.
  *
  * The shape will have a number of points equal to width x height. The points

--- a/examples/src/ABFExample.cpp
+++ b/examples/src/ABFExample.cpp
@@ -15,7 +15,7 @@ auto main() -> int
     // Create the mesh writer
     volcart::io::OBJWriter mesh_writer;
 
-    // Setup the test objects
+    // Set up the test objects
     volcart::shapes::Plane plane;
     volcart::shapes::Arch arch;
     volcart::shapes::Spiral spiral(20, 10);

--- a/graph/include/vc/graph/texturing.hpp
+++ b/graph/include/vc/graph/texturing.hpp
@@ -36,7 +36,6 @@ namespace volcart
  */
 class ABFNode : public smgl::Node
 {
-private:
     /** Flattening class type */
     using ABF = texturing::AngleBasedFlattening;
     /** Flattening class */
@@ -51,6 +50,8 @@ public:
     smgl::InputPort<ITKMesh::Pointer> input;
     /** @copydoc ABF::setUseABF(bool) */
     smgl::InputPort<bool> useABF;
+    /** @copydoc ABF::setSolver(Solver) */
+    smgl::InputPort<ABF::Solver> solver;
     /** @brief Flattened mesh */
     smgl::OutputPort<ITKMesh::Pointer> output;
     /** @brief UVMap generated from flattened mesh */

--- a/graph/src/texturing.cpp
+++ b/graph/src/texturing.cpp
@@ -40,6 +40,12 @@ NLOHMANN_JSON_SERIALIZE_ENUM(Direction, {
 namespace volcart::texturing
 {
 // clang-format off
+using Solver = AngleBasedFlattening::Solver;
+NLOHMANN_JSON_SERIALIZE_ENUM(Solver, {
+    {Solver::SparseLU, "sparse_lu"},
+    {Solver::ConjugateGradient, "conjugate_gradient"}
+})
+
 using Shading = PPMGeneratorNode::Shading;
 NLOHMANN_JSON_SERIALIZE_ENUM(Shading, {
     {Shading::Flat, "flat"},
@@ -81,11 +87,13 @@ ABFNode::ABFNode()
     : Node{true}
     , input{&abf_, &ABF::setMesh}
     , useABF{&abf_, &ABF::setUseABF}
+    , solver{&abf_, &ABF::setSolver}
     , output{&mesh_}
     , uvMap{&uvMap_}
 {
     registerInputPort("input", input);
     registerInputPort("useABF", useABF);
+    registerInputPort("solver", solver);
     registerOutputPort("output", output);
     registerOutputPort("uvMap", uvMap);
 
@@ -101,6 +109,7 @@ auto ABFNode::serialize_(bool useCache, const fs::path& cacheDir)
 {
     smgl::Metadata meta{
         {"useABF", abf_.useABF()},
+        {"solver", abf_.solver()},
         {"abfMaxIterations", abf_.abfMaxIterations()}};
 
     if (useCache and uvMap_ and not uvMap_->empty()) {
@@ -115,6 +124,7 @@ auto ABFNode::serialize_(bool useCache, const fs::path& cacheDir)
 void ABFNode::deserialize_(const smgl::Metadata& meta, const fs::path& cacheDir)
 {
     abf_.setUseABF(meta["useABF"].get<bool>());
+    abf_.setSolver(meta["solver"].get<Solver>());
     abf_.setABFMaxIterations(meta["abfMaxIterations"].get<std::size_t>());
 
     if (meta.contains("uvMap")) {

--- a/texturing/CMakeLists.txt
+++ b/texturing/CMakeLists.txt
@@ -29,6 +29,10 @@ set(private_deps
 )
 set(defs "")
 
+if(VC_USE_OPENMP)
+    list(APPEND private_deps OpenMP::OpenMP_CXX)
+endif()
+
 add_library(vc_texturing ${srcs})
 add_library(VC::texturing ALIAS vc_texturing)
 target_compile_definitions(vc_texturing PUBLIC ${defs})

--- a/texturing/include/vc/texturing/AngleBasedFlattening.hpp
+++ b/texturing/include/vc/texturing/AngleBasedFlattening.hpp
@@ -33,7 +33,7 @@ public:
     enum class Solver { SparseLU = 0, ConjugateGradient = 1 };
 
     /** Default maximum number of ABF iterations */
-    static const std::size_t DEFAULT_ITERATIONS{10};
+    static constexpr std::size_t DEFAULT_ITERATIONS{10};
 
     /** Pointer */
     using Pointer = std::shared_ptr<AngleBasedFlattening>;

--- a/texturing/include/vc/texturing/AngleBasedFlattening.hpp
+++ b/texturing/include/vc/texturing/AngleBasedFlattening.hpp
@@ -29,6 +29,9 @@ namespace volcart::texturing
 class AngleBasedFlattening : public FlatteningAlgorithm
 {
 public:
+    /** Solver implementation */
+    enum class Solver { SparseLU = 0, ConjugateGradient = 1 };
+
     /** Default maximum number of ABF iterations */
     static const std::size_t DEFAULT_ITERATIONS{10};
 
@@ -74,6 +77,23 @@ public:
     /**@}*/
 
     /**@{*/
+    /**
+     * @brief The numerical solver method
+     *
+     * @note When compiled with OpenMP support, certain Eigen solvers (e.g.
+     * ConjugateGradient) are multithreaded. The number of threads used is
+     * controlled globally through the OpenMP and/or Eigen interfaces. See
+     * [Eigen and
+     * multi-threading](https://libeigen.gitlab.io/eigen/docs-nightly/TopicMultiThreading.html)
+     * for more information.
+     */
+    void setSolver(Solver solver);
+
+    /** @copydoc setSolver(Solver) */
+    [[nodiscard]] auto solver() const -> Solver;
+    /**@}*/
+
+    /**@{*/
     /** @brief Compute the parameterization */
     auto compute() -> ITKMesh::Pointer override;
     /**@}*/
@@ -81,6 +101,8 @@ public:
 private:
     /** Whether to use ABF minimization */
     bool useABF_{true};
+    /** Solver method */
+    Solver solver_{Solver::SparseLU};
     /** Maximum number of ABF minimization iterations */
     std::size_t maxABFIterations_{DEFAULT_ITERATIONS};
 };

--- a/texturing/src/AngleBasedFlattening.cpp
+++ b/texturing/src/AngleBasedFlattening.cpp
@@ -14,15 +14,14 @@ using namespace volcart::texturing;
 
 using MatrixType = Eigen::SparseMatrix<double>;
 using HalfEdgeMesh = OpenABF::detail::ABF::Mesh<double>;
-using CGSolver =
-    Eigen::ConjugateGradient<MatrixType, Eigen::Lower | Eigen::Upper>;
 
 // SparseLU
 using ABF = OpenABF::ABFPlusPlus<double>;
 using LSCM = OpenABF::AngleBasedLSCM<double, HalfEdgeMesh>;
 // ConjugateGradient
-using ABF_CG = OpenABF::ABFPlusPlus<double, HalfEdgeMesh, CGSolver>;
-using LSCM_CG = OpenABF::AngleBasedLSCM<double, HalfEdgeMesh, CGSolver>;
+using CG = Eigen::ConjugateGradient<MatrixType, Eigen::Lower | Eigen::Upper>;
+using ABF_CG = OpenABF::ABFPlusPlus<double, HalfEdgeMesh, CG>;
+using LSCM_CG = OpenABF::AngleBasedLSCM<double, HalfEdgeMesh, CG>;
 
 AngleBasedFlattening::AngleBasedFlattening(const ITKMesh::Pointer& m)
     : FlatteningAlgorithm(m)

--- a/texturing/src/AngleBasedFlattening.cpp
+++ b/texturing/src/AngleBasedFlattening.cpp
@@ -1,5 +1,6 @@
 #include "vc/texturing/AngleBasedFlattening.hpp"
 
+#include <Eigen/IterativeLinearSolvers>
 #include <OpenABF/OpenABF.hpp>
 
 #include "vc/core/util/Logging.hpp"
@@ -11,9 +12,17 @@ using namespace volcart::meshmath;
 using namespace volcart::meshing;
 using namespace volcart::texturing;
 
+using MatrixType = Eigen::SparseMatrix<double>;
+using HalfEdgeMesh = OpenABF::detail::ABF::Mesh<double>;
+using CGSolver =
+    Eigen::ConjugateGradient<MatrixType, Eigen::Lower | Eigen::Upper>;
+
+// SparseLU
 using ABF = OpenABF::ABFPlusPlus<double>;
-using HalfEdgeMesh = ABF::Mesh;
 using LSCM = OpenABF::AngleBasedLSCM<double, HalfEdgeMesh>;
+// ConjugateGradient
+using ABF_CG = OpenABF::ABFPlusPlus<double, HalfEdgeMesh, CGSolver>;
+using LSCM_CG = OpenABF::AngleBasedLSCM<double, HalfEdgeMesh, CGSolver>;
 
 AngleBasedFlattening::AngleBasedFlattening(const ITKMesh::Pointer& m)
     : FlatteningAlgorithm(m)
@@ -63,7 +72,11 @@ auto AngleBasedFlattening::compute() -> ITKMesh::Pointer
         std::size_t iters{0};
         double grad{0};
         try {
-            ABF::Compute(hem, iters, grad, maxABFIterations_);
+            if (solver_ == Solver::SparseLU) {
+                ABF::Compute(hem, iters, grad, maxABFIterations_);
+            } else if (solver_ == Solver::ConjugateGradient) {
+                ABF_CG::Compute(hem, iters, grad, maxABFIterations_);
+            }
         } catch (const OpenABF::SolverException& e) {
             Logger()->warn("Failed to solve ABF++. Falling back to LSCM.");
             Logger()->debug("SolverException: {}", e.what());
@@ -74,15 +87,18 @@ auto AngleBasedFlattening::compute() -> ITKMesh::Pointer
 
     // LSCM
     Logger()->info("Solving LSCM");
-    LSCM::Compute(hem);
+    if (solver_ == Solver::SparseLU) {
+        LSCM::Compute(hem);
+    } else if (solver_ == Solver::ConjugateGradient) {
+        LSCM_CG::Compute(hem);
+    }
 
     // Fill output
     // OpenABF flattens to XY, but we want it on XZ
     Logger()->debug("Converting half-edge mesh to output mesh");
-    auto flatMesh = ITKMesh::New();
-    DeepCopy(mesh_, flatMesh);
+    auto flatMesh = DeepCopy(mesh_);
     ITKPoint pt;
-    cv::Vec3d norm{0.0, 1.0, 0.0};
+    const cv::Vec3d norm{0.0, 1.0, 0.0};
     for (const auto& v : hem->vertices()) {
         pt[0] = v->pos[0];
         pt[1] = 0.0;
@@ -106,3 +122,7 @@ auto AngleBasedFlattening::abfMaxIterations() const -> std::size_t
 {
     return maxABFIterations_;
 }
+
+void AngleBasedFlattening::setSolver(const Solver solver) { solver_ = solver; }
+
+auto AngleBasedFlattening::solver() const -> Solver { return solver_; }

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -147,6 +147,11 @@ target_link_libraries(vc_flatten_mesh
     VC::texturing
     ${VC_FS_LIB}
     Boost::program_options
+    Eigen3::Eigen
+)
+target_include_directories(vc_core
+    PUBLIC
+        $<BUILD_INTERFACE:${libcore_SOURCE_DIR}/include>
 )
 list(APPEND utils_install_list vc_flatten_mesh)
 

--- a/utils/src/FlattenMesh.cpp
+++ b/utils/src/FlattenMesh.cpp
@@ -31,7 +31,9 @@ auto main(int argc, char** argv) -> int
             "Output mesh file")
         ("method,m", po::value<std::string>()->default_value("ABF"), "Flattening method: [ABF, LSCM]")
         ("solver,s", po::value<std::string>()->default_value("SparseLU"), "Numerical solver method: [SparseLU, CG]")
-        ("threads,t", po::value<int>()->default_value(0), "Maximum number of threads");
+        ("threads,t", po::value<int>()->default_value(0), "Maximum number of threads")
+        ("log-level", po::value<std::string>()->default_value("info"),
+             "Options: off, critical, error, warn, info, debug");
 
     po::options_description all("Usage");
     all.add(required);
@@ -54,6 +56,10 @@ auto main(int argc, char** argv) -> int
         std::cerr << "ERROR: " << e.what() << '\n';
         return EXIT_FAILURE;
     }
+
+    // Set logging level
+    auto logLevel = parsed["log-level"].as<std::string>();
+    vc::logging::SetLogLevel(logLevel);
 
     // Get the method
     bool useABF{true};

--- a/utils/src/FlattenMesh.cpp
+++ b/utils/src/FlattenMesh.cpp
@@ -1,10 +1,11 @@
 #include <iostream>
 
+#include <Eigen/Eigen>
 #include <boost/program_options.hpp>
+#include <educelab/core/utils/String.hpp>
 
 #include "vc/core/filesystem.hpp"
-#include "vc/core/io/OBJReader.hpp"
-#include "vc/core/io/OBJWriter.hpp"
+#include "vc/core/io/MeshIO.hpp"
 #include "vc/core/util/Logging.hpp"
 #include "vc/texturing/AngleBasedFlattening.hpp"
 
@@ -12,6 +13,9 @@ namespace fs = volcart::filesystem;
 namespace po = boost::program_options;
 namespace vc = volcart;
 namespace vct = volcart::texturing;
+namespace el = educelab;
+
+using Solver = vct::AngleBasedFlattening::Solver;
 
 auto main(int argc, char** argv) -> int
 {
@@ -25,7 +29,9 @@ auto main(int argc, char** argv) -> int
             "Input mesh file")
         ("output-mesh,o", po::value<std::string>()->required(),
             "Output mesh file")
-        ("method,m", po::value<std::string>()->default_value("ABF"), "Flattening method: [ABF, LSCM]");
+        ("method,m", po::value<std::string>()->default_value("ABF"), "Flattening method: [ABF, LSCM]")
+        ("solver,s", po::value<std::string>()->default_value("SparseLU"), "Numerical solver method: [SparseLU, CG]")
+        ("threads,t", po::value<int>()->default_value(0), "Maximum number of threads");
 
     po::options_description all("Usage");
     all.add(required);
@@ -49,9 +55,9 @@ auto main(int argc, char** argv) -> int
         return EXIT_FAILURE;
     }
 
+    // Get the method
     bool useABF{true};
-    auto method = parsed["method"].as<std::string>();
-    std::transform(method.begin(), method.end(), method.begin(), ::tolower);
+    auto method = el::to_lower_copy(parsed["method"].as<std::string>());
     if (method == "lscm") {
         useABF = false;
     } else if (method != "abf") {
@@ -60,12 +66,24 @@ auto main(int argc, char** argv) -> int
         return EXIT_FAILURE;
     }
 
+    // Get the solver
+    auto solver = Solver::SparseLU;
+    const auto solverStr =
+        el::to_lower_copy(parsed["solver"].as<std::string>());
+    if (solverStr == "cg") {
+        solver = Solver::ConjugateGradient;
+    } else if (solverStr != "sparselu") {
+        std::cerr << "ERROR: Unknown solver: " << solverStr << '\n';
+        return EXIT_FAILURE;
+    }
+
+    // Set the number of threads (OpenMP only)
+    Eigen::setNbThreads(parsed["threads"].as<int>());
+
     // Load mesh
     vc::Logger()->info("Loading mesh...");
     fs::path inputPath = parsed["input-mesh"].as<std::string>();
-    vc::io::OBJReader reader;
-    reader.setPath(inputPath);
-    auto mesh = reader.read();
+    auto [mesh, uv, texture] = vc::ReadMesh(inputPath);
     vc::Logger()->info(
         "Mesh Loaded || Vertices: {} || Faces: {}", mesh->GetNumberOfPoints(),
         mesh->GetNumberOfCells());
@@ -73,13 +91,11 @@ auto main(int argc, char** argv) -> int
     // Run ABF
     vct::AngleBasedFlattening abf;
     abf.setUseABF(useABF);
+    abf.setSolver(solver);
     abf.setMesh(mesh);
     mesh = abf.compute();
 
     vc::Logger()->info("Writing mesh...");
     fs::path outputPath = parsed["output-mesh"].as<std::string>();
-    vc::io::OBJWriter writer;
-    writer.setPath(outputPath);
-    writer.setMesh(mesh);
-    writer.write();
+    vc::WriteMesh(outputPath, mesh, uv, texture);
 }


### PR DESCRIPTION
Adds `ConjugateGradient` solver option to `AngleBasedFlattening` to supplement the default (`SparseLU`). Accordingly, also adds a `--uv-solver` flag to `vc_render`.

CG is an iterative numerical method which significantly reduces the memory requirements for flattening large meshes. Though iteration is slower than direct computation with SparseLU, Eigen's Conjugate Gradient implementation can make use of OpenMP multi-threading to enable significant performance improvements compared to single threading.

## Flattening time vs. mesh size
_Evaluated on MBP 2023 (M3 Max, 128GB of RAM). All times are in seconds._
| Num. faces | SparseLU | CG (1 thread) | CG (12 threads) |
|---------|-----------|----|-----|
|       50k |                1.30 |                7.31 |                 4.33 |
|      100k |                2.96 |               28.34 |               12.32 |
|      200k   |              7.38 |              107.37 |              47.58 |
|      400k  |              19.84 |              433.05 |               195.36 |
|      600k |               35.69 |              961.60 |             486.76 |
|      800k|               55.82 |           1750.23 |              842.42 |
|        1m|                88.61|              3456.18|              1553.04|

## LSCM
This evaluation has revealed that the largest runtime bottleneck for flattening is currently Least Square Conformal Maps, which takes many times longer than ABF++ for large meshes. Historically, LSCM was used because it can compute a coherent, non-self intersecting parameterization from the angles already optimzed by ABF (this is the approach taken in Blender, for example). Alternative parameterizers should be considered, such as [Hierarchical LSCM](https://dl.acm.org/doi/10.5555/946250.946918).

## OpenMP
This PR adds optional support for OpenMP within the project. Usually, OpenMP is enabled automatically when detected by CMake, and you should use the new `VC_USE_OPENMP` CMake variable to enable/disable OpenMP support in your build. For most project apps that use `AngleBasedFlattening`, there is now a new `--threads` flag which will allow you to control the maximum number of threads.

On macOS, the compiler does not provide OpenMP, and there are many suggestions for how to enable it by installing alternative compilers. If you are simply building for local development, we recommend the following method which uses the OpenMP libraries provided by Homebrew:
```shell
# install the library version of OpenMP
brew install libomp

# configure the environment so CMake can find the library
export LDFLAGS=-L$(brew --prefix)/opt/libomp/lib
export OpenMP_ROOT=$(brew --prefix)/opt/libomp

# configure the project
cmake -S . -B build/ # ... other configuration flags
```