### PR TITLE
Volume: Fix missing slice exception not being caught

### DIFF
--- a/core/include/vc/core/types/Exceptions.hpp
+++ b/core/include/vc/core/types/Exceptions.hpp
@@ -19,21 +19,15 @@ namespace volcart
  *
  * @ingroup Types
  */
-class IOException : public std::exception
+class IOException : public std::runtime_error
 {
 public:
     /**@{*/
     /** Constructor */
-    explicit IOException(const char* msg) : msg_(msg) {}
+    explicit IOException(const char* msg) : std::runtime_error(msg) {}
 
     /** @copydoc IOException(const char* msg) */
-    explicit IOException(std::string msg) : msg_(std::move(msg)) {}
+    explicit IOException(const std::string& msg) : std::runtime_error(msg) {}
     /**@}*/
-
-    /** Return exception message */
-    const char* what() const noexcept override { return msg_.c_str(); }
-
-protected:
-    std::string msg_;
 };
 }  // namespace volcart


### PR DESCRIPTION
When working with a partially downloaded volume à la the Vesuvius Challenge tutorial, the VC GUI would crash when loading the volpkg. Ultimately, this was caused by the `Volume` class trying to catch the wrong exception type (`std::runtime_error`), thus leaving the actually type uncaught (`IOException` inherited from `std::exception`).

This PR changes `IOException` to to inherit from `std::runtime_error` to fix this issue.