### PR TITLE
Patch the CMake minimum required version for in-source dependencies

### DIFF
--- a/cmake/BuildIndicators.cmake
+++ b/cmake/BuildIndicators.cmake
@@ -2,6 +2,7 @@ FetchContent_Declare(
     indicators
     GIT_REPOSITORY https://github.com/p-ranav/indicators.git
     GIT_TAG 222382c
+    PATCH_COMMAND patch -p1 -i ${CMAKE_SOURCE_DIR}/cmake/patches/Indicators-CMakeMinVer.patch
     EXCLUDE_FROM_ALL
 )
 FetchContent_MakeAvailable(indicators)

--- a/cmake/Buildbvh.cmake
+++ b/cmake/Buildbvh.cmake
@@ -2,6 +2,7 @@ FetchContent_Declare(
   bvh
   GIT_REPOSITORY https://github.com/madmann91/bvh.git
   GIT_TAG 2fd0db6
+  PATCH_COMMAND patch -p1 -i ${CMAKE_SOURCE_DIR}/cmake/patches/bvh-CMakeMinVer.patch
   EXCLUDE_FROM_ALL
 )
 FetchContent_MakeAvailable(bvh)

--- a/cmake/patches/Indicators-CMakeMinVer.patch
+++ b/cmake/patches/Indicators-CMakeMinVer.patch
@@ -1,0 +1,10 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3aa13c6..58309d0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.8)
++cmake_minimum_required(VERSION 3.28)
+ 
+ if(DEFINED PROJECT_NAME)
+   set(INDICATORS_SUBPROJECT ON)

--- a/cmake/patches/bvh-CMakeMinVer.patch
+++ b/cmake/patches/bvh-CMakeMinVer.patch
@@ -1,0 +1,10 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a6c8b90..5beffc7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.9)
++cmake_minimum_required(VERSION 3.28)
+ 
+ project(bvh CXX)
+ 


### PR DESCRIPTION
Patches the following in-source dependencies to CMake minimum required version 2.28
- madmann91/bvh
- p-ranav/indicators