### PR TITLE
Set VC_MEMMAP_SUPPORTED cache variable correctly

### DIFF
--- a/cmake/CheckMemMap.cmake
+++ b/cmake/CheckMemMap.cmake
@@ -36,7 +36,7 @@ else()
     message(STATUS "MemMap support: none")
 endif()
 
-set(VC_MEMMAP_SUPPORTED VC_MEMMAP_SUPPORTED CACHE BOOL "Memory mapping is supported on this platform")
+set(VC_MEMMAP_SUPPORTED ${VC_MEMMAP_SUPPORTED} CACHE BOOL "Memory mapping is supported on this platform")
 if(VC_MEMMAP_SUPPORTED)
     add_compile_definitions(VC_MEMMAP_SUPPORTED=true)
 else()


### PR DESCRIPTION
Correctly sets the CMake `VC_MEMMAP_SUPPORTED` cache variable.

Closes #130 