### PR TITLE
Migrate to smgl v0.11.0-rc.2's new registration schema

### DIFF
--- a/cmake/Buildsmgl.cmake
+++ b/cmake/Buildsmgl.cmake
@@ -1,7 +1,7 @@
 FetchContent_Declare(
     smgl
-    GIT_REPOSITORY https://gitlab.com/educelab/smgl.git
-    GIT_TAG v0.10.1
+    GIT_REPOSITORY https://github.com/educelab/smgl.git
+    GIT_TAG v0.11.0-rc.2
     EXCLUDE_FROM_ALL
 )
 set(SMGL_BUILD_JSON ${VC_BUILD_JSON} CACHE INTERNAL "")

--- a/graph/src/graph.cpp
+++ b/graph/src/graph.cpp
@@ -12,60 +12,57 @@ auto RegisterNodesImpl() -> bool
 
     // clang-format off
     // Core
-    registered &= smgl::RegisterNode<
-        LoadVolumePkgNode,
-        VolumePkgPropertiesNode,
-        VolumeSelectorNode,
-        VolumePropertiesNode,
-        SegmentationSelectorNode,
-        SegmentationPropertiesNode,
-        MeshPropertiesNode,
-        LoadMeshNode,
-        WriteMeshNode,
-        AlignUVMapToAxisNode,
-        RotateUVMapNode,
-        FlipUVMapNode,
-        PlotUVMapNode,
-        LoadImageNode,
-        WriteImageNode,
-        WriteImageSequenceNode,
-        LoadPPMNode,
-        WritePPMNode,
-        PPMPropertiesNode,
-        LoadVolumetricMaskNode,
-        LoadTransformNode,
-        TransformSelectorNode,
-        InvertTransformNode,
-        TransformMeshNode,
-        TransformPPMNode
-    >();
+    registered &= smgl::RegisterNodes(
+        SMGL_NODE(volcart::LoadVolumePkgNode),
+        SMGL_NODE(volcart::VolumePkgPropertiesNode),
+        SMGL_NODE(volcart::VolumeSelectorNode),
+        SMGL_NODE(volcart::VolumePropertiesNode),
+        SMGL_NODE(volcart::SegmentationSelectorNode),
+        SMGL_NODE(volcart::SegmentationPropertiesNode),
+        SMGL_NODE(volcart::MeshPropertiesNode),
+        SMGL_NODE(volcart::LoadMeshNode),
+        SMGL_NODE(volcart::WriteMeshNode),
+        SMGL_NODE(volcart::AlignUVMapToAxisNode),
+        SMGL_NODE(volcart::RotateUVMapNode),
+        SMGL_NODE(volcart::FlipUVMapNode),
+        SMGL_NODE(volcart::PlotUVMapNode),
+        SMGL_NODE(volcart::LoadImageNode),
+        SMGL_NODE(volcart::WriteImageNode),
+        SMGL_NODE(volcart::WriteImageSequenceNode),
+        SMGL_NODE(volcart::LoadPPMNode),
+        SMGL_NODE(volcart::WritePPMNode),
+        SMGL_NODE(volcart::PPMPropertiesNode),
+        SMGL_NODE(volcart::LoadVolumetricMaskNode),
+        SMGL_NODE(volcart::LoadTransformNode),
+        SMGL_NODE(volcart::TransformSelectorNode),
+        SMGL_NODE(volcart::InvertTransformNode),
+        SMGL_NODE(volcart::TransformMeshNode),
+        SMGL_NODE(volcart::TransformPPMNode));
 
     // Meshing
-    registered &= smgl::RegisterNode<
-        MeshingNode,
-        ScaleMeshNode,
-        CalculateNumVertsNode,
-        LaplacianSmoothMeshNode,
-        ResampleMeshNode,
-        UVMapToMeshNode,
-        OrientNormalsNode
-    >();
+    registered &= smgl::RegisterNodes(
+        SMGL_NODE(volcart::MeshingNode),
+        SMGL_NODE(volcart::ScaleMeshNode),
+        SMGL_NODE(volcart::CalculateNumVertsNode),
+        SMGL_NODE(volcart::LaplacianSmoothMeshNode),
+        SMGL_NODE(volcart::ResampleMeshNode),
+        SMGL_NODE(volcart::UVMapToMeshNode),
+        SMGL_NODE(volcart::OrientNormalsNode));
 
     // Texturing
-    registered &= smgl::RegisterNode<
-        ABFNode,
-        OrthographicFlatteningNode,
-        FlatteningErrorNode,
-        PlotLStretchErrorNode,
-        PPMGeneratorNode,
-        CalculateNeighborhoodRadiusNode,
-        NeighborhoodGeneratorNode,
-        CompositeTextureNode,
-        IntersectionTextureNode,
-        IntegralTextureNode,
-        ThicknessTextureNode,
-        LayerTextureNode
-    >();
+    registered &= smgl::RegisterNodes(
+        SMGL_NODE(volcart::ABFNode),
+        SMGL_NODE(volcart::OrthographicFlatteningNode),
+        SMGL_NODE(volcart::FlatteningErrorNode),
+        SMGL_NODE(volcart::PlotLStretchErrorNode),
+        SMGL_NODE(volcart::PPMGeneratorNode),
+        SMGL_NODE(volcart::CalculateNeighborhoodRadiusNode),
+        SMGL_NODE(volcart::NeighborhoodGeneratorNode),
+        SMGL_NODE(volcart::CompositeTextureNode),
+        SMGL_NODE(volcart::IntersectionTextureNode),
+        SMGL_NODE(volcart::IntegralTextureNode),
+        SMGL_NODE(volcart::ThicknessTextureNode),
+        SMGL_NODE(volcart::LayerTextureNode));
     // clang-format on
 
     return registered;


### PR DESCRIPTION
## Summary

- Updated `graph/src/graph.cpp` to use smgl's new node-registration API: migrated from `smgl::RegisterNode<...>()` template instantiation to `smgl::RegisterNodes(SMGL_NODE(...), ...)` across all three registration groups (Core, Meshing, and Texturing nodes), wrapping each node type in the `SMGL_NODE` macro and fully qualifying names with the `volcart::` namespace.
- Bumped smgl dependency from v0.10.1 (GitLab mirror) to v0.11.0-rc.2 by updating `cmake/Buildsmgl.cmake` to fetch from the official GitHub repository (`github.com/educelab/smgl.git`), as the stale GitLab mirror lacks the new `RegisterNodes` and `SMGL_NODE` APIs, and v0.11.0-rc.2 is only tagged on GitHub.
- This dependency upgrade fixes a compilation failure in CI, enabling the graph module to build with smgl's revised public registration interface.