### PR TITLE
ci: pin fmt to 12.1.0 on macOS to work around spdlog incompatibility

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -65,6 +65,14 @@ jobs:
         run: |
           sudo rm -rf /Library/Developer/CommandLineTools/SDKs/MacOSX${{ matrix.os.exclude_sdk }}*.sdk
 
+      # Homebrew's fmt 12.2.0 broke compilation against spdlog (a Brewfile
+      # dependency). Pin fmt to the last compatible release until spdlog
+      # supports fmt 12.2.0. Tracking issue: educelab/volume-cartographer#147
+      - name: Pin fmt to 12.1.0 (workaround for spdlog/fmt 12.2.0 incompatibility)
+        run: |
+          brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/8c1fead169ea138bf6e0aec848593c7abe8ec482/Formula/f/fmt.rb
+          brew pin fmt
+
       - name: Install dependencies
         run: |
           brew bundle

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -69,9 +69,7 @@ jobs:
       # dependency). Pin fmt to the last compatible release until spdlog
       # supports fmt 12.2.0. Tracking issue: educelab/volume-cartographer#147
       - name: Pin fmt to 12.1.0 (workaround for spdlog/fmt 12.2.0 incompatibility)
-        run: |
-          brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/8c1fead169ea138bf6e0aec848593c7abe8ec482/Formula/f/fmt.rb
-          brew pin fmt
+        run: ./scripts/brew-pin-fmt.sh
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Homebrew can be used to install all of Volume Cartographer's dependencies. We
 provide a `Brewfile` to simplify this process.
 ```shell
 cd volume-cartographer/
+./scripts/brew-pin-fmt.sh  # workaround for spdlog/fmt 12.2.0 incompatibility, see #147
 brew bundle
 ```
 

--- a/ci/homebrew-pins/Formula/fmt.rb
+++ b/ci/homebrew-pins/Formula/fmt.rb
@@ -1,0 +1,53 @@
+# Pinned copy of homebrew-core's fmt formula from before the 12.2.0 bump,
+# which broke compilation against spdlog. See educelab/volume-cartographer#147.
+# Installed/pinned via scripts/brew-pin-fmt.sh; remove both once that issue
+# is resolved.
+class Fmt < Formula
+  desc "Open-source formatting library for C++"
+  homepage "https://fmt.dev/"
+  url "https://github.com/fmtlib/fmt/releases/download/12.1.0/fmt-12.1.0.zip"
+  sha256 "695fd197fa5aff8fc67b5f2bbc110490a875cdf7a41686ac8512fb480fa8ada7"
+  license "MIT"
+  head "https://github.com/fmtlib/fmt.git", branch: "master"
+
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "008ec3a1b84d5db3334383279f6aaf1da457a1173efb14e9bd1d41beb7f6d6da"
+    sha256 cellar: :any,                 arm64_sequoia: "18312bbc96d1074563572481084b3db66e35119b8f76b321f37a74d6a9d46b46"
+    sha256 cellar: :any,                 arm64_sonoma:  "ee29782046b7c86462e2a0cef189868a5a861c7d2b5989923da0499de3698ee6"
+    sha256 cellar: :any,                 sonoma:        "dedd10167d4ad5aa173d40ed13a19e1648db680fb0569114caffe822bad14554"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "84463daea1c23f94ae58abbf951987bea488c0161be4d9cbc785594d88f02d63"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c7c4de1f40ac72b6f014ee7690e9a005b6689d270d6ace076719de7484c7d85b"
+  end
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", "-DBUILD_SHARED_LIBS=TRUE", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    system "cmake", "-S", ".", "-B", "build-static", "-DBUILD_SHARED_LIBS=FALSE", *std_cmake_args
+    system "cmake", "--build", "build-static"
+    lib.install "build-static/libfmt.a"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~CPP
+      #include <iostream>
+      #include <string>
+      #include <fmt/format.h>
+      int main()
+      {
+        std::string str = fmt::format("The answer is {}", 42);
+        std::cout << str;
+        return 0;
+      }
+    CPP
+
+    system ENV.cxx, "test.cpp", "-std=c++11", "-o", "test",
+                  "-I#{include}",
+                  "-L#{lib}",
+                  "-lfmt"
+    assert_equal "The answer is 42", shell_output("./test")
+  end
+end

--- a/scripts/brew-pin-fmt.sh
+++ b/scripts/brew-pin-fmt.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Installs and pins the fmt version known to work with spdlog, working
+# around the incompatibility introduced in fmt 12.2.0. Run this before
+# `brew bundle` (in CI or locally). See educelab/volume-cartographer#147.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tap_name="educelab/volume-cartographer-pins"
+
+if ! brew tap-info "$tap_name" &>/dev/null; then
+  # `brew tap` clones its source with git, so stage the formula in a throwaway
+  # git repo rather than nesting a real .git inside this repo's worktree.
+  tap_src="$(mktemp -d)"
+  trap 'rm -rf "$tap_src"' EXIT
+  cp -R "$repo_root/ci/homebrew-pins/." "$tap_src/"
+  git -C "$tap_src" init -q
+  git -C "$tap_src" -c user.name=brew-pin-fmt -c user.email=brew-pin-fmt@localhost \
+    add -A
+  git -C "$tap_src" -c user.name=brew-pin-fmt -c user.email=brew-pin-fmt@localhost \
+    commit -q -m "Pinned fmt formula"
+  brew tap "$tap_name" "$tap_src"
+fi
+
+current="$(brew list --formula --full-name | grep -x -e fmt -e "$tap_name/fmt" || true)"
+if [ "$current" = "fmt" ]; then
+  # Installed from homebrew/core (or another tap) under the same name;
+  # swap it for our pinned formula.
+  brew unpin fmt 2>/dev/null || true
+  brew uninstall --ignore-dependencies fmt
+fi
+
+brew install "$tap_name/fmt"
+brew pin fmt


### PR DESCRIPTION
## Summary
- Homebrew bumped `fmt` 12.1.0 → 12.2.0, which deprecated the implicit `format_string`/`fstring` → `string_view` conversion that `spdlog` (a direct `Brewfile` dependency, used throughout `VC::core` for logging) relies on, breaking macOS CI builds.
- VTK is not implicated — it vendors and privately namespaces its own copy of fmt (`vtk_fmt.h`, `VTK_MODULE_USE_EXTERNAL_VTK_fmt=0`), so it never touches the system fmt version.
- Adds a step to the macOS job that installs fmt from the last homebrew-core commit before the 12.2.0 bump and pins it, before `brew bundle` runs.
- Opened #147 to track removing this pin once spdlog/Homebrew support fmt 12.2.0.
- The fix already exists upstream in spdlog's `v1.x` branch (commit [`1685e694c5`](https://github.com/gabime/spdlog/commit/1685e694c5), #3541) but hasn't been cut into a release since `v1.17.0` (2026-01-04) — see #147 for the exact unblock condition.

## Test plan
- [x] macOS CI job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)